### PR TITLE
Fix untranslatable strings #2

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
                                 <label for="delay" data-translate="Duration (in hours):"></label>
                                 <input type="number" pattern="[0-9]*" data-highlight="true" data-type="range" value="0" min="0" max="96" id="delay" />
                             </div>
-                            <input type="submit" value="Submit" data-theme="b" />
+                            <script>$("form").append("<input type=\"submit\" value=\""+_("Submit")+"\" data-theme=\"b\" />")</script>
                         </form>
                     </li>
                 </ul>

--- a/js/main.js
+++ b/js/main.js
@@ -426,7 +426,7 @@ function show_addnew(autoIP) {
                     '<input '+((isAuto) ? 'data-role="none" style="display:none" ' : '')+'autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="url" name="os_ip" id="os_ip" value="'+((isAuto) ? autoIP : '')+'" placeholder="home.dyndns.org" />' +
                     '<label for="os_pw">'+_("Open Sprinkler Password:")+'</label>' +
                     '<input type="password" name="os_pw" id="os_pw" value="" />' +
-                    '<input type="submit" value="Submit" />' +
+                    '<input type="submit" value="'+_("Submit")+'" />' +
                 '</form>' +
             '</div>' +
         '</div>');
@@ -942,7 +942,7 @@ function show_settings() {
     }
 
     if (typeof window.controller.options.mas !== "undefined") {
-        list += "<label for='o18' class='select'>"+_("Master Station")+"</label><select data-mini='true' id='o18'><option value='0'>None</option>";
+        list += "<label for='o18' class='select'>"+_("Master Station")+"</label><select data-mini='true' id='o18'><option value='0'>"+_("n/a")+"</option>";
         for (i=0; i<window.controller.stations.snames.length; i++) {
             list += "<option "+(((i+1) == window.controller.options.mas) ? "selected" : "")+" value='"+(i+1)+"'>"+window.controller.stations.snames[i]+"</option>";
             if (i == 7) break;


### PR DESCRIPTION
Hi!

Thanks for the last merger and sorry for the little bug (assuming that var "lang" was global), but I'm not a javascript expert at all :-(!
While reviewing the German App Version I noticed 3 minor translation issues which I tried to fix! 

-) As "None" appeared twice and as for German I need to distinguish I introduced "n/a" instead of "None" for the master station. I don't know if "n/a"/"not applicable" fit in here?
-) To translate the "Submit" Button for the rain delay I found no other way than using jquery/append. I don't know if this appropriate for your!

Thanks & kind regards
// Clemens
