### PR TITLE
Added ability to set reference weather conditions (Temp, Rain, Humidty) to the Zimmerman adjustment method

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -304,7 +304,7 @@ module.exports = function( grunt ) {
 		},
 
 		uglify: {
-			makeFW: {
+			buildFW: {
 				files: {
 					"www/js/app.js": [ "www/js/jquery.js", "www/js/main.js", "www/js/libs.js" ]
 				}
@@ -331,8 +331,8 @@ module.exports = function( grunt ) {
 	grunt.registerTask( "test", [ "default", "blanket_mocha" ] );
 	grunt.registerTask( "updateLang", [ "shell:updateLang" ] );
 	grunt.registerTask( "pushEng", [ "shell:pushEng" ] );
-        grunt.registerTask( "buildFW", [ "default", "uglify", "cssmin", "compress:jsAsset", "compress:cssAsset", "compress:makeFW" ] );
-	grunt.registerTask( "makeFW", [ "default", "uglify", "cssmin", "compress:jsAsset", "compress:cssAsset", "compress:makeFW", "clean:makeFW" ] );
+	grunt.registerTask( "buildFW", [ "default", "uglify", "cssmin", "compress:jsAsset", "compress:cssAsset" ] );
+	grunt.registerTask( "makeFW", [ "buildFW", "compress:makeFW", "clean:makeFW" ] );
 	grunt.registerTask( "pushFW", [ "makeFW", "shell:updateUI", "clean:pushFW" ] );
 	grunt.registerTask( "pushBetaFW", [ "makeFW", "shell:updateBetaUI", "clean:pushFW" ] );
 	grunt.registerTask( "build", [ "default", "shell:symres", "shell:blackberry10", "compress:firefox", "compress:chrome", "compress:blackberry10", "pushFW", "clean:symres" ] );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -331,6 +331,7 @@ module.exports = function( grunt ) {
 	grunt.registerTask( "test", [ "default", "blanket_mocha" ] );
 	grunt.registerTask( "updateLang", [ "shell:updateLang" ] );
 	grunt.registerTask( "pushEng", [ "shell:pushEng" ] );
+        grunt.registerTask( "buildFW", [ "default", "uglify", "cssmin", "compress:jsAsset", "compress:cssAsset", "compress:makeFW" ] );
 	grunt.registerTask( "makeFW", [ "default", "uglify", "cssmin", "compress:jsAsset", "compress:cssAsset", "compress:makeFW", "clean:makeFW" ] );
 	grunt.registerTask( "pushFW", [ "makeFW", "shell:updateUI", "clean:pushFW" ] );
 	grunt.registerTask( "pushBetaFW", [ "makeFW", "shell:updateBetaUI", "clean:pushFW" ] );


### PR DESCRIPTION
Samer/Ray,

I have done three pull requests (one on Firmware, one on App and one on Weather) to add the ability to adjust the baseline weather conditions in the Zimmerman adjustment method. See forum thread https://opensprinkler.com/forums/topic/zimmerman-parameters/

- App - main.js, I have extended the showZimmermanAdjustmentOptions function to include three additional input fields to capture the reference temperature, humidity and daily rainfall. In addition, I have used weather.forecast.region to determine the locale and from that whether to display in metric or imperial. I am uncertain if that object is always defined and would like confirmation that it is therefore available for use. It is set when wunderground is enabled and is referenceable in Zimmerman function but perhaps there are conditions when this is not so. The function converts to/from imperial when communicating with Firmware.

- Weather – server.js: I have modified server.js to take the three reference parameters but to use default values of Temp = 70F, Humidity = 30% and Daily Rain = 0in if these references are not passed. This provides backwards compatibility with previous versions.

- Firmware – wtopts.txt: although wto options are largely transparent to Firmware, this change extends the wtopts.txt file with three new options (bh, br, bt) for the baseline weather conditions: bh is a percentage humidity; br is daily rainfall in inches to three decimals; and bt is degrees fahrenheiht to two decimal places. The precision is so we can convert to metric in the UI while still retaining tenths of degrees celsius and mm. This results in an increase to the size of wtopts.txt to a maximum of 55 bytes.

- Firmware – weather.cpp: I see in weather.cpp that a char tmp[100] buffer is used to store wtopts.txt on OSPi which looks fine. However, a char tmp[30] is used on Arduino. I am unsure how much memory headroom is available under Arduino and whether the array can be extended to 60 bytes. Do you see this as a problem as I could look a bit harder to reduce the memory increase?

Samer, I have just noticed that a change (dccee37) I made to App Gruntfile.js has mistakenly come through as well. This change was to add a new grunt task "buildFW" that creates app.jgz/app.cgz and leaves them in the www directory so that they are available for my test environment. The nearest existing task was "makeFW" but that bundles them into UI.zip and then removes them from app/www. I am new to grunt so I may be missing somethings obvious. Would be great if you would accept this commit but feel free to discard if not to your liking.

Thanks, Peter