### PR TITLE
Added support for HTTP Stations

### DIFF
--- a/www/css/main.css
+++ b/www/css/main.css
@@ -55,6 +55,36 @@ a {
     text-decoration:none
 }
 
+/* Station tab rules */
+
+ul.tabs {
+	margin: 0px;
+	padding: 0px;
+	list-style: none;
+}
+
+ul.tabs li {
+	background: none;
+	display: inline-block;
+	padding: 10px 15px;
+	cursor: pointer;
+}
+
+ul.tabs li.current {
+	background: #ededed;
+}
+
+.tab-content {
+	display: none;
+	background: #ededed;
+	padding: 15px;
+	width: 200px;
+}
+
+.tab-content.current {
+	display: inherit;
+}
+
 /*
     Additional Icons
 */
@@ -840,6 +870,7 @@ div.running-text{
     font-size:.71em!important;
     white-space: normal !important;
 }
+
 
 /* Program preview rules */
 .master {

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -4784,11 +4784,11 @@ var showHome = ( function() {
 						sd += select.find( "#active-state" ).val() || "1";
 						button.data( "specialData", sd );
 					} else if ( hs === 4 ) {
-						var sd = select.find( "#http-server" ).val();
-							sd += "," + select.find( "#http-port" ).val();
-							sd += "," + select.find( "#http-on" ).val();
-							sd += "," + select.find( "#http-off" ).val();
-						button.data( "specialData", sd );
+						var sdata = select.find( "#http-server" ).val();
+						sdata += "," + select.find( "#http-port" ).val();
+						sdata += "," + select.find( "#http-on" ).val();
+						sdata += "," + select.find( "#http-off" ).val();
+						button.data( "specialData", sdata );
                     }
 
                     button.data( "um", select.find( "#um" ).is( ":checked" ) ? 1 : 0 );
@@ -4883,11 +4883,11 @@ var showHome = ( function() {
 				select += "<div id='tab-advanced' class='tab-content'>" +
 					"<div class='ui-bar-a ui-bar'>" + _( "Station Type" ) + ":</div>" +
 						"<select data-mini='true' id='hs'"  + ( isStationSpecial( id ) ? " class='ui-disabled'" : "" ) + ">" +
-							"<option data-hs='0' value='0'" + ( isStationSpecial( id ) ? "" : "selected") + ">" + _( "Standard" ) + "</option>" +
+							"<option data-hs='0' value='0'" + ( isStationSpecial( id ) ? "" : "selected" ) + ">" + _( "Standard" ) + "</option>" +
 							"<option data-hs='1' value='1'>" + _( "RF" ) + "</option>" +
 							"<option data-hs='2' value='2'>" + _( "Remote" ) + "</option>" +
 							"<option data-hs='3' value='3'" + ( checkOSVersion( 2162 ) && ( getHWVersion() === "OSPi" ) ? ">" : " disabled>" ) + _( "GPIO" ) + "</option>" +
-							"<option data-hs='4' value='4'" + ( checkOSVersion( 2162 ) && ( getHWVersion() === "OSPi" ) ? ">" : " disabled>" ) + _( "HTTP" ) + "</option>" +
+							"<option data-hs='4' value='4'" + ( checkOSVersion( 217 ) && ( getHWVersion() === "OSPi" ) ? ">" : " disabled>" ) + _( "HTTP" ) + "</option>" +
 						"</select>" +
 						"<div id='specialOpts'></div>" +
 					"</div>" +
@@ -4904,18 +4904,18 @@ var showHome = ( function() {
 
 			// Display the selected tab when clicked
 			select.find( "ul.tabs li" ).click( function() {
-				var tab_id = $( this ).attr( "data-tab" );
+				var tabId = $( this ).attr( "data-tab" );
 
 				$( "ul.tabs li" ).removeClass( "current" );
 				$( ".tab-content" ).removeClass( "current" );
 
 				$( this ).addClass( "current" );
-				$( "#" + tab_id ).addClass( "current" );
-			})
+				$( "#" + tabId ).addClass( "current" );
+			} );
 
 			// Update Advanced tab whenever a new special station type is selected
             select.find( "#hs" ).on( "change", function() {
-				var value = parseInt( $(this).val() );
+				var value = parseInt( $( this ).val() );
 				showSpecialOptions( value );
 				return false;
             } );

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -4644,7 +4644,7 @@ var showHome = ( function() {
 							"<input class='center' data-corners='false' data-wrapper-class='tight ui-btn stn-name' id='rf-code' required='true' type='text' value='" + data + "'>"
 						).enhanceWithin();
 					} else if ( value === 2 ) {
-						data = ( type === value ) ? parseRemoteStationData( data ) : parseRemoteStationData( "00000000005000" );
+						data = parseRemoteStationData( ( type === value ) ? data : "00000000005000" );
 
 						opts.append(
 							"<div class='ui-bar-a ui-bar'>" + _( "Remote Address" ) + ":</div>" +


### PR DESCRIPTION
There are changes across both Firmware and App to support this feature.

The HTTP Station is a simple extension of the existing handler routines in both App and Firmware. This is very similar to the Remote Station code and allows the user to send HTTP GET commands to a server by configuring the following settings { Server, Port, On command, Off command }.

I have used a simple comma separated string to hold the above four parameters when transferring special data between App and Firmware using the api calls. This is a little different to the other Special Stations that use fixed width parameters. I did this because I wanted to support server names, in addition to IP addresses, and the On/Off commands can be arbitrary length.

In Firmware, I have extended the SpecialStationData structure from 23 to 120 bytes, i.e. the scratch buffer size, so that we can store complex On/Off commands (e.g. with hashed passwords or user tokens). This results in stns.dat file around four times the original size but still only ~4k so hoping that this is acceptable.

In the App, the number of Special Station Types is getting quite significant and the parameters were resulting in a really tall Station Attribute dialogue box. So I have introduced a “tabbed” version of the dialogue with Basic/Advanced pages. This keeps things a little more tidy. 

Given the change to the stns.dat file format, this feature should really come in on a major version upgrade as it will require the user to do an export/import of settings to avoid stns.dat file corruption.

There are some things that I thought might be worth adding if you think useful:

- Specify whether a GET or POST message is used
- Select between “send and refresh” or “single shot” approach to keeping HTTP Station is sync
- Strip out any initial “/” entered by the user for the On or Off command entered into the App 