### PR TITLE
Fix buffer overrun when storing long station configuration

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -4834,16 +4834,39 @@ var showHome = ( function() {
 
 						opts.append(
 							"<div class='ui-bar-a ui-bar'>" + _( "Server Name" ) + ":</div>" +
-							"<input class='center' data-corners='false' data-wrapper-class='tight ui-btn stn-name' id='http-server' required='true' type='text' value='" + data[ 0 ] + "'>" +
+							"<input class='center  validate-length' data-corners='false' data-wrapper-class='tight ui-btn stn-name' id='http-server' required='true' type='text' value='" + data[ 0 ] + "'>" +
 							"<div class='ui-bar-a ui-bar'>" + _( "Server Port" ) + ":</div>" +
-							"<input class='center' data-corners='false' data-wrapper-class='tight ui-btn stn-name' id='http-port' required='true' type='number' min='0' max='65535' value='" + parseInt( data[ 1 ] ) + "'>" +
+							"<input class='center  validate-length' data-corners='false' data-wrapper-class='tight ui-btn stn-name' id='http-port' required='true' type='number' min='0' max='65535' value='" + parseInt( data[ 1 ] ) + "'>" +
 							"<div class='ui-bar-a ui-bar'>" + _( "On Command" ) + ":</div>" +
-							"<input class='center' data-corners='false' data-wrapper-class='tight ui-btn stn-name' id='http-on' required='true' type='text' value='" + data[ 2 ] + "'>" +
+							"<input class='center validate-length' data-corners='false' data-wrapper-class='tight ui-btn stn-name' id='http-on' required='true' type='text' value='" + data[ 2 ] + "'>" +
 							"<div class='ui-bar-a ui-bar'>" + _( "Off Command" ) + ":</div>" +
-							"<input class='center' data-corners='false' data-wrapper-class='tight ui-btn stn-name' id='http-off' required='true' type='text' value='" + data[ 3 ] + "'>"
+							"<input class='center validate-length' data-corners='false' data-wrapper-class='tight ui-btn stn-name' id='http-off' required='true' type='text' value='" + data[ 3 ] + "'>" +
+							"<div class='center smaller' id='character-tracking' style='color:#999;'>" +
+								"<p>" +	_( "Note: There is a limit on the number of character used to configure this station type." ) + "</p>" +
+								"<span>" + _( "Characters remaining" ) + ": </span><span id='character-count'>placeholder</span>" +
+							"</div>"
 						).enhanceWithin();
+
+						validateLength();
+						$( ".validate-length" ).on( "input", validateLength );
 					}
                 },
+				validateLength = function() {
+					var maxSDChars = 240,		// Maximum size of special data when uri encoded. Needs to be less than sizeof(SpecialStationData) i.e. 247 bytes
+					    sd = select.find( "#http-server" ).val() + "," + select.find( "#http-port" ).val() + "," +
+							 select.find( "#http-on" ).val() + "," + select.find( "#http-off" ).val(),
+						sdLen = encodeURIComponent( sd ).length;
+
+					select.find( "#character-count" ).text( maxSDChars - sdLen );
+
+					if ( sdLen > maxSDChars ) {
+						select.find( ".attrib-submit" ).addClass( "ui-disabled" );
+						select.find( "#character-tracking" ).addClass( "red-text bold" );
+					} else {
+						select.find( ".attrib-submit" ).removeClass( "ui-disabled" );
+						select.find( "#character-tracking" ).removeClass( "red-text bold" );
+					}
+				},
                 saveChanges = function( checkPassed ) {
 					var hs = parseInt( select.find( "#hs" ).val() );
                     button.data( "hs", hs );


### PR DESCRIPTION
Hey Ray/Samer,

Apologies for the delay in getting this PR in. Things have just been a bit manic at work and home. I have created this PR against both Firmware and App to correct for a buffer overrun if a user specifies a very long HTTP On/Off command in Station Settings dialogue.

PR1: App - Introduced logic to keep track of the URI Encoded length of the HTTP Station configuration parameters. I ensure that the User's configuration is constrained such that they cannot save a set of parameters that would overrun either Firmware TMP_BUFFER or SpecialStationData. i.e. they have around 240 character to play with when encoded (say 2/3rds of that in clear text) for on/off commands. See below for screen shot.

PR2: Firmware - Current findKeyVal logic will truncate a Value string if longer than tmp_buffer's 255 bytes. This could result in corrupt config passing into the system. Although this situation should never arise, the bug in my HTTP Station code did trigger this scenario. An alternative logic, provided in the PR, rejects any key/value pair that cannot be contained in the receiving buffer. An alternative would be to change the return value to "signed" and signal a truncation error.

Let me know if any thoughts/changes required and happy to rework as needed.
Cheers, Pete
![fix_http_station](https://user-images.githubusercontent.com/16738570/27547688-a66fb9fe-5a8e-11e7-80f5-540b2ce1c46b.jpg)
