### PR TITLE
Fix import routine to uri encode station special data

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -9293,7 +9293,7 @@ function importConfig( data ) {
             } ),
             $.each( data.special, function( sid, info ) {
 				if ( checkOSVersion( 216 ) ) {
-	                sendToOS( "/cs?pw=&sid=" + sid + "&st=" + info.st + "&sd=" + info.sd );
+	                sendToOS( "/cs?pw=&sid=" + sid + "&st=" + info.st + "&sd=" + encodeURIComponent( info.sd ) );
 	            }
             } )
         ).then(


### PR DESCRIPTION
Samer , I have seen on the forum [here](https://opensprinkler.com/forums/topic/bug-http-stationos-2-32-1-7-url-length-limitation-causes-erratic-behavior/#post-51161) that the Station Special Data can be corrupted when importing configuration from file.

Looking at the code, I can see that the App import function does not uri encode the special data before sending to OS. This means that "&" characters in the on/off commands for http stations are not escaped and get misinterpreted by Firmware server.cpp as delimiters.

I probably should have picked this up during the original testing as I dont think any of the other special station config requires encoding.

Might be worth looking at some of the other fields in importConfig() to see if they also require encoding.