### PR TITLE
Fix bug causing updateController to never be used for refresh

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -5548,7 +5548,7 @@ function refreshStatus( failOverMethod ) {
 	};
 
 	if ( !( useFailOverMethodForRefresh || failOverMethod ) && checkOSVersion( 216 ) ) {
-		updateController( finish, refreshStatus.call( this, true ) );
+		updateController( finish, refreshStatus.bind( this, true ) );
 	} else {
 		$.when(
 			updateControllerStatus(),


### PR DESCRIPTION
By using `call` the function is immediately called and the value of `useFailOverMethodForRefresh` gets set to true. This uses bind so the parameters we want are set but the function is only called if needed.