### PR TITLE
Don't set isMetric based on region field in forecast

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -2761,8 +2761,6 @@ function updateWeather() {
 				return;
 			}
 
-			isMetric = ( data.region !== "US" && data.region !== "BM" && data.region !== "PW" );
-
 			currentCoordinates = data.location;
 
 			weather = data;


### PR DESCRIPTION
Since the `region` field in the response is now always empty, this value was always being set to `true`.