### PR TITLE
Add wto and ifkey to imports

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -8946,6 +8946,16 @@ function importConfig( data ) {
 			co += "&o36=1";
 		}
 
+		// Import Weather Adjustment Options, if available
+		if ( typeof data.settings.wto === "object" && checkOSVersion( 215 ) ) {
+			co += "&wto=" + escapeJSON( data.settings.wto );
+		}
+
+		// Import IFTTT Key, if available
+		if ( typeof data.settings.ifkey === "string" && checkOSVersion( 217 ) ) {
+			co += "&ifkey=" + data.settings.ifkey;
+		}
+
 		co += "&" + ( isPi ? "o" : "" ) + "loc=" + data.settings.loc;
 
 		for ( i = 0; i < data.stations.snames.length; i++ ) {


### PR DESCRIPTION
Hey Samer, as per Slack. I had a go at amending the import routine. I left `wtkey` alone as it looks like it will fall under `wto` going forward. Let me know if anything needs changing.