### PR TITLE
Enhance map with WUnderground

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -3053,12 +3053,14 @@ function overlayMap( callback ) {
 			} catch ( err ) { exit( false ); }
 		},
 		updateStations = function( latitude, longitude ) {
-			if ( !controller.settings.wto || typeof controller.settings.wto.key !== "string" || controller.settings.wto.key === "" ) {
+			var key = $( "#wtkey" ).val();
+			if ( key === "" ) {
 				return;
 			}
 
 			$.ajax( {
-				url: "https://api.weather.com/v3/location/near?format=json&product=pws&apiKey=" + controller.settings.wto.key + "&geocode=" + encodeURIComponent( latitude ) + "," + encodeURIComponent( longitude ),
+				url: "https://api.weather.com/v3/location/near?format=json&product=pws&apiKey=" + key +
+						"&geocode=" + encodeURIComponent( latitude ) + "," + encodeURIComponent( longitude ),
 				cache: true
 			} ).done( function( data ) {
 				var sortedData = [];
@@ -3068,7 +3070,7 @@ function overlayMap( callback ) {
 						id: id,
 						lat: data.location.latitude[ index ],
 						lon: data.location.longitude[ index ],
-						message: data.location.stationName[ index ]
+						message: data.location.stationId[ index ]
 					} );
 				} );
 

--- a/www/js/map.js
+++ b/www/js/map.js
@@ -50,6 +50,10 @@ function initialize() {
 			streetViewControl: false,
 			mapTypeControl: false,
 			mapTypeId: google.maps.MapTypeId.ROADMAP,
+			zoomControl: true,
+			zoomControlOptions: {
+				position: google.maps.ControlPosition.LEFT_BOTTOM
+			},
 			styles: [
 				{ featureType: "poi", elementType: "labels", stylers: [ { visibility: "off" } ] },
 				{ featureType: "transit", elementType: "labels", stylers: [ { visibility: "off" } ] }


### PR DESCRIPTION
Sorry for multiple updates in the one PR and I can split out if preferred:

- Use the "current" value of `#wtkey` rather than the saved version from `controller.settings.wto.key` in order to display PWS stations on map. This avoids the need for having to save the setting before it can take effect.

- Show PWS ID rather than location name (i.e. "ILONDON654" rather than "London") in the PWS Info Box when selecting a PWS "blue" dot. This is helpful when there are more than one PWS in close proximity.

- Move the zoom controls to the other side of the map to avoid overlapping with the main App control box.
