### PR TITLE
Add support for grouped stations

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -3525,19 +3525,19 @@ function showOptions( expandItem ) {
 		"</div>" ),
 		generateSensorOptions = function( index, sensorType, number ) {
 			return "<div class='ui-field-contain'>" +
-			    "<fieldset data-role='controlgroup' class='ui-mini center sensor-options' data-type='horizontal'>" +
-			        "<legend class='left'>" + _( "Sensor" ) + ( number ? " " + number + " " : " " ) + _( "Type" ) + "</legend>" +
-			        "<input class='noselect' type='radio' name='o" + index + "' id='o" + index + "-none' value='0'" + ( sensorType === 0 ? " checked='checked'" : "" ) + ">" +
-			        "<label for='o" + index + "-none'>" + _( "None" ) + "</label>" +
-			        "<input class='noselect' type='radio' name='o" + index + "' id='o" + index + "-rain' value='1'" + ( sensorType === 1 ? " checked='checked'" : "" ) + ">" +
-			        "<label for='o" + index + "-rain'>" + _( "Rain" ) + "</label>" +
+				"<fieldset data-role='controlgroup' class='ui-mini center sensor-options' data-type='horizontal'>" +
+					"<legend class='left'>" + _( "Sensor" ) + ( number ? " " + number + " " : " " ) + _( "Type" ) + "</legend>" +
+					"<input class='noselect' type='radio' name='o" + index + "' id='o" + index + "-none' value='0'" + ( sensorType === 0 ? " checked='checked'" : "" ) + ">" +
+					"<label for='o" + index + "-none'>" + _( "None" ) + "</label>" +
+					"<input class='noselect' type='radio' name='o" + index + "' id='o" + index + "-rain' value='1'" + ( sensorType === 1 ? " checked='checked'" : "" ) + ">" +
+					"<label for='o" + index + "-rain'>" + _( "Rain" ) + "</label>" +
 					( index === 52 ? "" : "<input class='noselect' type='radio' name='o" + index + "' id='o" + index + "-flow' value='2'" + ( sensorType === 2 ? " checked='checked'" : "" ) + ">" +
-			        	"<label for='o" + index + "-flow'>" + _( "Flow" ) + "</label>" ) +
-			        ( checkOSVersion( 219 ) ? "<input class='noselect' type='radio' name='o" + index + "' id='o" + index + "-soil' value='3'" + ( sensorType === 3 ? " checked='checked'" : "" ) + ">" +
-			        	"<label for='o" + index + "-soil'>" + _( "Soil" ) + "</label>" : "" ) +
-			        ( checkOSVersion( 217 ) ? "<input class='noselect' type='radio' name='o" + index + "' id='o" + index + "-program' value='240'" + ( sensorType === 240 ? " checked='checked'" : "" ) + ">" +
-			        	"<label for='o" + index + "-program'>" + _( "Program Switch" ) + "</label>" : "" ) +
-			    "</fieldset>" +
+						"<label for='o" + index + "-flow'>" + _( "Flow" ) + "</label>" ) +
+					( checkOSVersion( 219 ) ? "<input class='noselect' type='radio' name='o" + index + "' id='o" + index + "-soil' value='3'" + ( sensorType === 3 ? " checked='checked'" : "" ) + ">" +
+						"<label for='o" + index + "-soil'>" + _( "Soil" ) + "</label>" : "" ) +
+					( checkOSVersion( 217 ) ? "<input class='noselect' type='radio' name='o" + index + "' id='o" + index + "-program' value='240'" + ( sensorType === 240 ? " checked='checked'" : "" ) + ">" +
+						"<label for='o" + index + "-program'>" + _( "Program Switch" ) + "</label>" : "" ) +
+				"</fieldset>" +
 			"</div>";
 		},
 		submitOptions = function() {
@@ -4968,6 +4968,7 @@ var showHome = ( function() {
 				( hasAR ? ( "data-ar='" + ( ( controller.stations.act_relay[ parseInt( i / 8 ) ] & ( 1 << ( i % 8 ) ) ) ? 1 : 0 ) + "' " ) : "" ) +
 				( hasSD ? ( "data-sd='" + ( ( controller.stations.stn_dis[ parseInt( i / 8 ) ] & ( 1 << ( i % 8 ) ) ) ? 1 : 0 ) + "' " ) : "" ) +
 				( hasSequential ? ( "data-us='" + ( ( controller.stations.stn_seq[ parseInt( i / 8 ) ] & ( 1 << ( i % 8 ) ) ) ? 1 : 0 ) + "' " ) : "" ) +
+				( hasGroup ? ( "data-grp='" + controller.stations.stn_grp[i] + "' " ) : "" ) +
 				( hasSpecial ? ( "data-hs='" + ( ( controller.stations.stn_spe[ parseInt( i / 8 ) ] & ( 1 << ( i % 8 ) ) ) ? 1 : 0 ) + "' " ) : "" ) +
 				"></span>";
 
@@ -5199,6 +5200,7 @@ var showHome = ( function() {
 					button.data( "ar", select.find( "#ar" ).is( ":checked" ) ? 1 : 0 );
 					button.data( "sd", select.find( "#sd" ).is( ":checked" ) ? 1 : 0 );
 					button.data( "us", select.find( "#us" ).is( ":checked" ) ? 1 : 0 );
+					button.data( "grp", select.find( "#grp" ).val() );
 					name.html( select.find( "#stn-name" ).val() );
 
 					// Update the notes section
@@ -5283,6 +5285,11 @@ var showHome = ( function() {
 					select += "<label for='us'><input class='needsclick' data-iconpos='right' id='us' type='checkbox' " +
 							( ( button.data( "us" ) === 1 ) ? "checked='checked'" : "" ) + ">" + _( "Sequential" ) +
 						"</label>";
+				}
+
+				if ( hasGroup ) {
+					select += "<div class='ui-bar-a ui-bar'>" + _( "Grouping" ) + ":</div><input class='center' data-corners='false' data-wrapper-class='tight stn-name ui-btn' id='grp' type='text' value='" + button.data( "grp" ) +
+						"'>";
 				}
 			}
 
@@ -5382,6 +5389,7 @@ var showHome = ( function() {
 				master = {},
 				master2 = {},
 				sequential = {},
+				group = {},
 				special = {},
 				rain = {},
 				sensor1 = {},
@@ -5436,6 +5444,10 @@ var showHome = ( function() {
 						sequential[ "q" + bid ] = ( sequential[ "q" + bid ] ) + ( attrib.data( "us" ) << s );
 					}
 
+					if ( hasGroup) {
+						group[ "g" + (bid*8 + s) ] = attrib.data( "grp" );
+					}
+
 					if ( hasSpecial ) {
 						special[ "p" + bid ] = ( special[ "p" + bid ] ) + ( ( attrib.data( "hs" ) ? 1 : 0 ) << s );
 					}
@@ -5484,6 +5496,7 @@ var showHome = ( function() {
 				( hasMaster ? "&" + $.param( master ) : "" ) +
 				( hasMaster2 ? "&" + $.param( master2 ) : "" ) +
 				( hasSequential ? "&" + $.param( sequential ) : "" ) +
+				( hasGroup ? "&" + $.param( group ) : "" ) +
 				( hasSpecial ? "&" + $.param( special ) : "" ) +
 				( hasIR ? "&" + $.param( rain ) : "" ) +
 				( hasSN1 ? "&" + $.param( sensor1 ) : "" ) +
@@ -5582,6 +5595,7 @@ var showHome = ( function() {
 			hasAR = ( typeof controller.stations.act_relay === "object" ) ? true : false;
 			hasSD = ( typeof controller.stations.stn_dis === "object" ) ? true : false;
 			hasSequential = ( typeof controller.stations.stn_seq === "object" ) ? true : false;
+			hasGroup = ( typeof controller.stations.stn_grp === "object" ) ? true : false;
 			hasSpecial = ( typeof controller.stations.stn_spe === "object" ) ? true : false;
 
 			for ( var i = 0; i < controller.stations.snames.length; i++ ) {
@@ -5630,6 +5644,7 @@ var showHome = ( function() {
 						ar: hasAR ? ( ( controller.stations.act_relay[ parseInt( i / 8 ) ] & ( 1 << ( i % 8 ) ) ) ? 1 : 0 ) : undefined,
 						sd: hasSD ? ( ( controller.stations.stn_dis[ parseInt( i / 8 ) ] & ( 1 << ( i % 8 ) ) ) ? 1 : 0 ) : undefined,
 						us: hasSequential ? ( ( controller.stations.stn_seq[ parseInt( i / 8 ) ] & ( 1 << ( i % 8 ) ) ) ? 1 : 0 ) : undefined,
+						grp: hasGroup ? controller.stations.stn_grp[i] : undefined,
 						hs: hasSpecial ? ( ( controller.stations.stn_spe[ parseInt( i / 8 ) ] & ( 1 << ( i % 8 ) ) ) ? 1 : 0 ) : undefined
 					} );
 
@@ -5680,7 +5695,7 @@ var showHome = ( function() {
 				callback();
 			} );
 		},
-		hasMaster, hasMaster2, hasIR, hasSN1, hasSN2, hasAR, hasSD, hasSequential, hasSpecial, cards, siteSelect, currentSite, i, sites;
+		hasMaster, hasMaster2, hasIR, hasSN1, hasSN2, hasAR, hasSD, hasSequential, hasGroup, hasSpecial, cards, siteSelect, currentSite, i, sites;
 
 	page.one( "pageshow", function() {
 		$( "html" ).on( "datarefresh", updateContent );
@@ -5699,6 +5714,7 @@ var showHome = ( function() {
 		hasAR = ( typeof controller.stations.act_relay === "object" ) ? true : false;
 		hasSD = ( typeof controller.stations.stn_dis === "object" ) ? true : false;
 		hasSequential = ( typeof controller.stations.stn_seq === "object" ) ? true : false;
+		hasGroup = ( typeof controller.stations.stn_grp === "object" ) ? true : false;
 		hasSpecial = ( typeof controller.stations.stn_spe === "object" ) ? true : false;
 
 		cards = "";
@@ -6775,7 +6791,7 @@ var getPreview = ( function() {
 			// Station qid for FW 2.1.6+
 			qidArray = new Array( nstations ),
 			lastStopTime = 0,
-			lastSeqStopTime = 0,
+			lastSeqStopTime = new Array(16),
 			busy, matchFound, prog, sid, qid, q, sqi, bid, bid2, s, s2;
 
 		for ( sid = 0; sid < nstations; sid++ ) {
@@ -6830,6 +6846,7 @@ var getPreview = ( function() {
 												dur: waterTime,
 												sid: sid,
 												pid: pid + 1,
+												gid: controller.stations.stn_grp ? controller.stations.stn_grp[sid] : 0,
 												pl: 1
 											} );
 										}
@@ -6852,11 +6869,11 @@ var getPreview = ( function() {
 			}
 			if ( matchFound ) {
 				var acctime = simminutes * 60,
-					seqAcctime = acctime;
+					seqAcctime = new Array(lastSeqStopTime.length);
 
 				if ( is211 ) {
-					if ( lastSeqStopTime > acctime ) {
-						seqAcctime = lastSeqStopTime + controller.options.sdt;
+					for (var i = 0; i < seqAcctime.length; i++) {
+						seqAcctime[i] = Math.max(acctime, lastSeqStopTime[i] + controller.options.sdt);
 					}
 
 					if ( is216 ) {
@@ -6873,9 +6890,9 @@ var getPreview = ( function() {
 							bid2 = sid >> 3;
 							s2 = sid & 0x07;
 							if ( controller.stations.stn_seq[ bid2 ] & ( 1 << s2 ) ) {
-								q.st = seqAcctime;
-								seqAcctime += q.dur;
-								seqAcctime += controller.options.sdt;
+								q.st = seqAcctime[q.gid];
+								seqAcctime[q.gid] += q.dur;
+								seqAcctime[q.gid] += controller.options.sdt;
 							} else {
 								q.st = acctime;
 								acctime++;
@@ -6890,8 +6907,8 @@ var getPreview = ( function() {
 								continue;
 							}
 							if ( controller.stations.stn_seq[ bid2 ] & ( 1 << s2 ) ) {
-								startArray[ sid ] = seqAcctime;seqAcctime += endArray[ sid ];
-								endArray[ sid ] = seqAcctime;seqAcctime += controller.options.sdt;
+								startArray[ sid ] = seqAcctime[0];seqAcctime[0] += endArray[ sid ];
+								endArray[ sid ] = seqAcctime[0];seqAcctime[0] += controller.options.sdt;
 								plArray[ sid ] = 1;
 							} else {
 								startArray[ sid ] = acctime;
@@ -6975,7 +6992,7 @@ var getPreview = ( function() {
 				}
 
 				// Lastly, calculate lastSeqStopTime
-				lastSeqStopTime = 0;
+				for (var i = 0; i < lastSeqStopTime.length; i++) lastSeqStopTime[i] = 0;
 				for ( qid = 0; qid < rtQueue.length; qid++ ) {
 					q = rtQueue[ qid ];
 					sid = q.sid;
@@ -6983,8 +7000,8 @@ var getPreview = ( function() {
 					s2 = sid & 0x07;
 					var sst = q.st + q.dur;
 					if ( controller.stations.stn_seq[ bid2 ] & ( 1 << s2 ) ) {
-						if ( sst > lastSeqStopTime ) {
-							lastSeqStopTime = sst;
+						if ( sst > lastSeqStopTime[q.gid] ) {
+							lastSeqStopTime[q.gid] = sst;
 						}
 					}
 				}
@@ -6993,7 +7010,7 @@ var getPreview = ( function() {
 				// Handle firmwares prior to 2.1.6
 				if ( busy ) {
 					if ( is211 ) {
-						lastSeqStopTime = runSched( simminutes * 60, startArray, programArray, endArray, plArray, simt );
+						lastSeqStopTime[0] = runSched( simminutes * 60, startArray, programArray, endArray, plArray, simt );
 						simminutes++;
 						for ( sid = 0; sid < controller.settings.nbrd * 8; sid++ ) {
 							if ( programArray[ sid ] > 0 && simminutes * 60 >= endArray[ sid ] ) {


### PR DESCRIPTION
I'm adding support for reading & modifying the station groups ids, which is not yet merged into the OpenSprinkler firmware but hopefully will be soon (see https://github.com/OpenSprinkler/OpenSprinkler-Firmware/pull/171 + another PR to come).

Since these changes keep compatibility with the existing firmware, I thought I'd submit this one early. Compatibility is kept by giving every station a default group id of zero, which is equivalent to just not having groups.

Screenshot of the field to edit the station id in zone settings:

<img width="903" alt="image" src="https://user-images.githubusercontent.com/18223213/115820001-d51fbd80-a3b4-11eb-82cb-c5b5c914d4d7.png">

I'm not familiar with the UI library the app uses, so I just copied the station field name and un-bolded the text inside the input. A much thinner field that aligns with the checkboxes (group ids go from only 0 to 15) would be ideal, but I didn't know how to make that.

Also, grouping ids are irrelevant & should be disabled if sequential is unchecked, but I don't know what the best way to go about that is.

Preview program view (`S01` and `S02` are group 1, `S03`, `S04`, and `S05` are group 2):

<img width="961" alt="image" src="https://user-images.githubusercontent.com/18223213/115820293-58411380-a3b5-11eb-84e5-602b1a0a741e.png">

The same set of programs, after reverting to the latest OpenSprinkler firmware:

<img width="962" alt="image" src="https://user-images.githubusercontent.com/18223213/115820624-0d73cb80-a3b6-11eb-95e3-e7a5b7ffb774.png">
