### PR TITLE
chore(vers): bump version to 2.4.2

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="113" id="com.albahra.sprinklers" version="2.4.2" versionCode="114" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="114" id="com.albahra.sprinklers" version="2.4.2" versionCode="115" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>OpenSprinkler</name>
     <description>
 	    Designed to allow intuitive control of the OpenSprinkler irrigation controller.
@@ -42,7 +42,7 @@
             <string>Your camera is used to provide an image for your stations.</string>
         </config-file>
         <config-file target="*-Info.plist" overwrite="true" parent="CFBundleShortVersionString">
-            <string>19906</string>
+            <string>191006</string>
         </config-file>
         <config-file target="*-Info.plist" overwrite="true" parent="LSApplicationCategoryType">
             <string>public.app-category.utilities</string>

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="113" id="com.albahra.sprinklers" version="2.4.1" versionCode="114" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="113" id="com.albahra.sprinklers" version="2.4.2" versionCode="114" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>OpenSprinkler</name>
     <description>
 	    Designed to allow intuitive control of the OpenSprinkler irrigation controller.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "opensprinkler",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "opensprinkler",
-			"version": "2.4.1",
+			"version": "2.4.2",
 			"license": "AGPL-3.0",
 			"devDependencies": {
 				"blanket": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "opensprinkler",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"description": "Designed to allow intuitive control of the OpenSprinkler irrigation controller.",
 	"keywords": [
 		"sprinklers",

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -10626,7 +10626,7 @@ var showAbout = ( function() {
 					"</li>" +
 				"</ul>" +
 				"<p class='smaller'>" +
-					_( "App Version" ) + ": 2.4.1" +
+					_( "App Version" ) + ": 2.4.2" +
 					"<br>" + _( "Firmware" ) + ": <span class='firmware'></span>" +
 					"<br><span class='hardwareLabel'>" + _( "Hardware Version" ) + ":</span> <span class='hardware'></span>" +
 				"</p>" +


### PR DESCRIPTION
#### Changes Proposed

- Bumps version to 2.4.2
- Note: I am having issues getting old cached content/js back from the betaui site. Please see video

#### Demo Video or Screenshots



https://github.com/user-attachments/assets/7cb8b261-6ec6-43d4-a4b0-e74f9ec17f56

