### PR TITLE
chore(vers): bump version to 2.4.2

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="113" id="com.albahra.sprinklers" version="2.4.1" versionCode="114" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="114" id="com.albahra.sprinklers" version="2.4.2" versionCode="115" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>OpenSprinkler</name>
     <description>
 	    Designed to allow intuitive control of the OpenSprinkler irrigation controller.
@@ -42,7 +42,7 @@
             <string>Your camera is used to provide an image for your stations.</string>
         </config-file>
         <config-file target="*-Info.plist" overwrite="true" parent="CFBundleShortVersionString">
-            <string>19906</string>
+            <string>191006</string>
         </config-file>
         <config-file target="*-Info.plist" overwrite="true" parent="LSApplicationCategoryType">
             <string>public.app-category.utilities</string>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "opensprinkler",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"description": "Designed to allow intuitive control of the OpenSprinkler irrigation controller.",
 	"keywords": [
 		"sprinklers",

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -10626,7 +10626,7 @@ var showAbout = ( function() {
 					"</li>" +
 				"</ul>" +
 				"<p class='smaller'>" +
-					_( "App Version" ) + ": 2.4.1" +
+					_( "App Version" ) + ": 2.4.2" +
 					"<br>" + _( "Firmware" ) + ": <span class='firmware'></span>" +
 					"<br><span class='hardwareLabel'>" + _( "Hardware Version" ) + ":</span> <span class='hardware'></span>" +
 				"</p>" +


### PR DESCRIPTION
#### Changes Proposed

- Bump version to 2.4.2 using `grunt bump` task
- Note: I am seeing some Cloudflare caching issues when loading betaui. Recently added features are not appearing. Please see video for more info

#### Demo Video or Screenshots


https://github.com/user-attachments/assets/c4fdf276-e253-498c-b822-a50c69a97f96


