### PR TITLE
chore(deploy): fix grunt makeFW command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # NPM package location
 node_modules/
 
+# Build output
+build/
+
 # Cordova folders
 platforms/
 plugins/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,7 @@
 						archive: "build/firmware/UI.zip"
 					},
 					files: [ {
-						src: [ "css/**", "js/**", "img/**", "locale/*.js", "*.html", "manifest.json", "sw.js" ],
+						src: [ "css/**", "js/**", "vendor-js/**", "img/**", "locale/*.js", "*.html", "manifest.json", "sw.js" ],
 						cwd: "www/",
 						expand: true
 					}, {

--- a/build/firmware/.gitignore
+++ b/build/firmware/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="116" id="com.albahra.sprinklers" version="2.4.4" versionCode="117" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="117" id="com.albahra.sprinklers" version="2.4.5" versionCode="118" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>OpenSprinkler</name>
     <description>
 	    Designed to allow intuitive control of the OpenSprinkler irrigation controller.
@@ -42,7 +42,7 @@
             <string>Your camera is used to provide an image for your stations.</string>
         </config-file>
         <config-file target="*-Info.plist" overwrite="true" parent="CFBundleShortVersionString">
-            <string>193006</string>
+            <string>194006</string>
         </config-file>
         <config-file target="*-Info.plist" overwrite="true" parent="LSApplicationCategoryType">
             <string>public.app-category.utilities</string>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "opensprinkler",
-	"version": "2.4.4",
+	"version": "2.4.5",
 	"description": "Designed to allow intuitive control of the OpenSprinkler irrigation controller.",
 	"keywords": [
 		"sprinklers",

--- a/www/js/modules/ui-dom.js
+++ b/www/js/modules/ui-dom.js
@@ -3583,7 +3583,7 @@ OSApp.UIDom.launchApp = function() {
 						"</li>" +
 					"</ul>" +
 					"<p class='smaller'>" +
-						OSApp.Language._( "App Version" ) + ": 2.4.4" + // FIXME: This needs to be pulled from package.json automatcally (or replaced during build/deploy!!) mellodev
+						OSApp.Language._( "App Version" ) + ": 2.4.5" + // FIXME: This needs to be pulled from package.json automatcally (or replaced during build/deploy!!) mellodev
 						"<br>" + OSApp.Language._( "Firmware" ) + ": <span class='firmware'></span>" +
 						"<br><span class='hardwareLabel'>" + OSApp.Language._( "Hardware Version" ) + ":</span> <span class='hardware'></span>" +
 					"</p>" +


### PR DESCRIPTION
#### Changes Proposed

- Update the gruntfile task `compress:makeFW` to properly include the new `/vendor-js` folder
- Bumps version to 2.4.5
- Adds `/build` to `.gitignore`
- ⚠️ I noticed that the transifx tasks in gruntfile will be broken until we update them with the new paths! Will make a gh issue about that problem.

#### Demo Video or Screenshots

![image](https://github.com/user-attachments/assets/9977ee83-ec60-4839-8258-ffaf1b905bf3)
