### PR TITLE
fix(logs): station grouping issue 195

### DIFF
--- a/www/js/modules/dates.js
+++ b/www/js/modules/dates.js
@@ -163,6 +163,10 @@ OSApp.Dates.humaniseDuration = function( base, relative ) {
 };
 
 OSApp.Dates.dateToString = function( date, toUTC, shorten ) {
+	if (!date) {
+		return '--';
+	}
+
 	var dayNames = [ OSApp.Language._( "Sun" ), OSApp.Language._( "Mon" ), OSApp.Language._( "Tue" ),
 					OSApp.Language._( "Wed" ), OSApp.Language._( "Thu" ), OSApp.Language._( "Fri" ), OSApp.Language._( "Sat" ) ],
 		monthNames = [ OSApp.Language._( "Jan" ), OSApp.Language._( "Feb" ), OSApp.Language._( "Mar" ), OSApp.Language._( "Apr" ), OSApp.Language._( "May" ), OSApp.Language._( "Jun" ),

--- a/www/js/modules/logs.js
+++ b/www/js/modules/logs.js
@@ -111,7 +111,8 @@ OSApp.Logs.displayPage = function() {
 				if ( type === "table" ) {
 					switch ( grouping ) {
 						case "station":
-							sortedData[ station ].push( [ utc, OSApp.Dates.dhms2str( OSApp.Dates.sec2dhms( duration ) ) ] );
+							var stationItem = [ utc, OSApp.Dates.dhms2str( OSApp.Dates.sec2dhms( duration ) ), station, new Date( utc.getTime() + ( duration * 1000 ) ) ];
+							sortedData[ station ].push( stationItem );
 							break;
 						case "day":
 							var day = Math.floor( date.getTime() / 1000 / 60 / 60 / 24 ),
@@ -376,11 +377,29 @@ OSApp.Logs.displayPage = function() {
 					groupArray[ i ] += tableHeader;
 
 					for ( k = 0; k < sortedData[ group ].length; k++ ) {
+						var stationName, runTime, startTime, endTime;
+						switch ( grouping ) {
+							case 'station':
+								stationName = stations[ group ];
+								runTime = sortedData[ group ][ k ][ 1 ];
+								startTime = formatTime( sortedData[ group ][ k ][ 0 ], grouping ) ;
+								endTime = formatTime( sortedData[ group ][ k ][ 3 ], grouping ); // this is undefined
+								break;
+
+							case 'day':
+							default:
+								stationName = stations[ sortedData[ group ][ k ][ 2 ] ];
+								runTime = sortedData[ group ][ k ][ 1 ];
+								startTime = formatTime( sortedData[ group ][ k ][ 0 ], grouping ) ;
+								endTime = formatTime( sortedData[ group ][ k ][ 3 ], grouping );
+								break;
+						}
+
 						groupArray[ i ] += "<tr>" +
-							"<td>" + stations[ sortedData[ group ][ k ][ 2 ] ] + "</td>" + // Station name
-							"<td>" + sortedData[ group ][ k ][ 1 ] + "</td>" + // Runtime
-							"<td>" + formatTime( sortedData[ group ][ k ][ 0 ], grouping ) + "</td>" + // Startdate
-							"<td>" + formatTime( sortedData[ group ][ k ][ 3 ], grouping ) + "</td>" + // Enddate
+							"<td>" + stationName + "</td>" + // Station name
+							"<td>" + runTime + "</td>" + // Runtime
+							"<td>" + startTime + "</td>" + // Startdate
+							"<td>" + endTime + "</td>" + // Enddate
 							"</tr>";
 					}
 					groupArray[ i ] += "</tbody></table></div>";

--- a/www/js/modules/logs.js
+++ b/www/js/modules/logs.js
@@ -377,23 +377,10 @@ OSApp.Logs.displayPage = function() {
 					groupArray[ i ] += tableHeader;
 
 					for ( k = 0; k < sortedData[ group ].length; k++ ) {
-						var stationName, runTime, startTime, endTime;
-						switch ( grouping ) {
-							case 'station':
-								stationName = stations[ group ];
-								runTime = sortedData[ group ][ k ][ 1 ];
-								startTime = formatTime( sortedData[ group ][ k ][ 0 ], grouping ) ;
-								endTime = formatTime( sortedData[ group ][ k ][ 3 ], grouping ); // this is undefined
-								break;
-
-							case 'day':
-							default:
-								stationName = stations[ sortedData[ group ][ k ][ 2 ] ];
-								runTime = sortedData[ group ][ k ][ 1 ];
-								startTime = formatTime( sortedData[ group ][ k ][ 0 ], grouping ) ;
-								endTime = formatTime( sortedData[ group ][ k ][ 3 ], grouping );
-								break;
-						}
+						var stationName = ( grouping === 'station' ) ? stations[ group ] : stations[ sortedData[ group ][ k ][ 2 ] ];
+						var runTime = sortedData[ group ][ k ][ 1 ];
+						var startTime = formatTime( sortedData[ group ][ k ][ 0 ], grouping ) ;
+						var endTime = formatTime( sortedData[ group ][ k ][ 3 ], grouping );
 
 						groupArray[ i ] += "<tr>" +
 							"<td>" + stationName + "</td>" + // Station name


### PR DESCRIPTION
#### Changes Proposed

- Fixes [issue #195 with station grouping](https://github.com/OpenSprinkler/OpenSprinkler-App/issues/195) in log view throwing exception
- Updates `Dates.dateToString` to gracefully return `--` when undefined date is passed
- Refactors log view `prepTable` logic to properly set station name when grouping is station
- Updates `sortData` to properly assign endDate value when grouping is station

#### Demo Video or Screenshots

https://github.com/user-attachments/assets/aaba909f-5b92-4120-9adc-9e6985e2c702



