### PR TITLE
feat(error-handler): improve generic error handling

### DIFF
--- a/.github/workflows/app-store-connect.yml
+++ b/.github/workflows/app-store-connect.yml
@@ -77,10 +77,6 @@ jobs:
         run: |
           sed -i.bak "s|appVersion: '[0-9\.]*'|appVersion: '${{ steps.gitversion.outputs.semVer }}'|" www/main.js
 
-      - name: Update about.js version
-        run: |
-          sed -E -i.bak 's|(\$\{OSApp\.Language\._\("App Version"\)\}: )0\.0\.0|\1${{ steps.gitversion.outputs.semVer }}|' www/js/modules/about.js
-
       - name: Update config.xml versions
         run: |
           # Update version attribute

--- a/.github/workflows/app-store-connect.yml
+++ b/.github/workflows/app-store-connect.yml
@@ -73,6 +73,10 @@ jobs:
         run: |
           sed -i.bak "s|OpenSprinkler-v[0-9\.]*|OpenSprinkler-v${{ steps.gitversion.outputs.semVer }}|" www/sw.js
 
+      - name: Update main.js App Version
+        run: |
+          sed -i.bak "s|appVersion: '[0-9\.]*'|appVersion: '${{ steps.gitversion.outputs.semVer }}'|" www/main.js
+
       - name: Update about.js version
         run: |
           sed -E -i.bak 's|(\$\{OSApp\.Language\._\("App Version"\)\}: )0\.0\.0|\1${{ steps.gitversion.outputs.semVer }}|' www/js/modules/about.js

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Choose an environment to deploy'
+        description: "Choose an environment to deploy"
         required: true
-        default: 'dev'
+        default: "dev"
         type: choice
         options:
           - dev
@@ -34,7 +34,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.0.0
         with:
-          versionSpec: '5.x'
+          versionSpec: "5.x"
 
       - name: Run GitVersion
         id: gitversion
@@ -49,6 +49,10 @@ jobs:
       - name: Update sw.js version
         run: |
           sed -i.bak "s|OpenSprinkler-v[0-9\.]*|OpenSprinkler-v${{ steps.gitversion.outputs.semVer }}|" www/sw.js
+
+      - name: Update main.js App Version
+        run: |
+          sed -i.bak "s|appVersion: '[0-9\.]*'|appVersion: '${{ steps.gitversion.outputs.semVer }}'|" www/main.js
 
       - name: Update about.js version
         run: |
@@ -92,8 +96,8 @@ jobs:
           projectId: opensprinkler-ui
           target: ${{
             github.event_name == 'workflow_dispatch' && (
-              github.event.inputs.environment == 'prod' && 'opensprinkler-ui' ||
-              github.event.inputs.environment == 'beta' && 'opensprinkler-betaui' ||
-              'opensprinkler-devui'
+            github.event.inputs.environment == 'prod' && 'opensprinkler-ui' ||
+            github.event.inputs.environment == 'beta' && 'opensprinkler-betaui' ||
+            'opensprinkler-devui'
             ) || 'opensprinkler-devui' }}
           channelId: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'live' || '' }}

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -54,10 +54,6 @@ jobs:
         run: |
           sed -i.bak "s|appVersion: '[0-9\.]*'|appVersion: '${{ steps.gitversion.outputs.semVer }}'|" www/main.js
 
-      - name: Update about.js version
-        run: |
-          sed -E -i.bak 's|(\$\{OSApp\.Language\._\("App Version"\)\}: )0\.0\.0|\1${{ steps.gitversion.outputs.semVer }}|' www/js/modules/about.js
-
       - name: Update config.xml versions
         run: |
           # Update version attribute

--- a/.github/workflows/google-play.yml
+++ b/.github/workflows/google-play.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
           sed -i.bak "s|OpenSprinkler-v[0-9\.]*|OpenSprinkler-v${{ steps.gitversion.outputs.semVer }}|" www/sw.js
 
+      - name: Update main.js App Version
+        run: |
+          sed -i.bak "s|appVersion: '[0-9\.]*'|appVersion: '${{ steps.gitversion.outputs.semVer }}'|" www/main.js
+
       - name: Update about.js version
         run: |
           sed -E -i.bak 's|(\$\{OSApp\.Language\._\("App Version"\)\}: )0\.0\.0|\1${{ steps.gitversion.outputs.semVer }}|' www/js/modules/about.js

--- a/.github/workflows/google-play.yml
+++ b/.github/workflows/google-play.yml
@@ -51,10 +51,6 @@ jobs:
         run: |
           sed -i.bak "s|appVersion: '[0-9\.]*'|appVersion: '${{ steps.gitversion.outputs.semVer }}'|" www/main.js
 
-      - name: Update about.js version
-        run: |
-          sed -E -i.bak 's|(\$\{OSApp\.Language\._\("App Version"\)\}: )0\.0\.0|\1${{ steps.gitversion.outputs.semVer }}|' www/js/modules/about.js
-
       - name: Update config.xml Versions
         run: |
           # Update version attribute (version name)

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -91,6 +91,7 @@ OSApp.currentDevice.isFileCapable = !OSApp.currentDevice.isiOS && !OSApp.current
 
 // UI state
 OSApp.uiState = {
+	appVersion: '0.0.0', // This is replaced at runtime by Gruntfile.js
 	errorTimeout: undefined,
 	goingBack: false,
 	is24Hour: false,

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -91,7 +91,7 @@ OSApp.currentDevice.isFileCapable = !OSApp.currentDevice.isiOS && !OSApp.current
 
 // UI state
 OSApp.uiState = {
-	appVersion: '0.0.0', // This is replaced at runtime by Gruntfile.js
+	appVersion: '0.0.0', // This is replaced at build time by a github workflow step
 	errorTimeout: undefined,
 	goingBack: false,
 	is24Hour: false,

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -20,9 +20,10 @@ var OSApp = OSApp || {};
 // TODO: add unit tests for each module
 // TODO: move vendor js (jquery, jqm, datatables, etc) to /js/vendor
 
-window.onerror = function( m, s, l, c, e ) {
-	// Catch any uncaught exceptions and write them to console
-	console.error( "*** Uncaught Exception", e );
+window.onerror = function(message, source, lineno, colno, error) {
+	// Catch any uncaught exceptions. Write them to console, show the user a modal to report the error.
+	console.error( "*** Uncaught Exception", {message, source, lineno, colno, error} );
+	OSApp.Errors.showErrorModal(message, source, lineno, colno, error);
 	return true;
 };
 
@@ -40,7 +41,7 @@ OSApp.Constants = {
 		"wl":23, "den":24, "ipas":25, "devid":26, "con":27, "lit":28, "dim":29, "bst":30, "uwt":31, "ntp1":32, "ntp2":33,
 		"ntp3":34, "ntp4":35, "lg":36, "mas2":37, "mton2":38, "mtof2":39, "fpr0":41, "fpr1":42, "re":43, "dns1": 44,
 		"dns2":45, "dns3":46, "dns4":47, "sar":48, "ife":49, "sn1t":50, "sn1o":51, "sn2t":52, "sn2o":53, "sn1on":54,
-		"sn1of":55, "sn2on":56, "sn2of":57, "subn1":58, "subn2":59, "subn3":60, "subn4":61, "laton":62, "latof":63, 
+		"sn1of":55, "sn2on":56, "sn2of":57, "subn1":58, "subn2":59, "subn3":60, "subn4":61, "laton":62, "latof":63,
 		"ife2":64, "imin":66
 	},
 	options: { // Option constants

--- a/www/js/modules/about.js
+++ b/www/js/modules/about.js
@@ -56,7 +56,7 @@ OSApp.About.displayPage = function() {
 					</li>
 				</ul>
 				<p class="smaller">
-					${OSApp.Language._("App Version")}: 0.0.0
+					${OSApp.Language._("App Version")}: ${OSApp.uiState.appVersion}
 					<br>
 					${OSApp.Language._("Firmware")}: <span class="firmware"></span>
 					<br>

--- a/www/js/modules/dashboard.js
+++ b/www/js/modules/dashboard.js
@@ -23,7 +23,6 @@ OSApp.Dashboard.displayPage = function() {
 	var page = $(`
 		<div data-role="page" id="sprinklers">
 			<div class="ui-panel-wrapper">
-				<button id="throw_error" onClick="OSApp.Utils.does_not_exist('1234'); return false;">Throw error</button>
 				<div class="ui-content" role="main">
 					<div class="ui-grid-a ui-body ui-corner-all info-card noweather">
 						<div class="ui-block-a">

--- a/www/js/modules/dashboard.js
+++ b/www/js/modules/dashboard.js
@@ -23,6 +23,7 @@ OSApp.Dashboard.displayPage = function() {
 	var page = $(`
 		<div data-role="page" id="sprinklers">
 			<div class="ui-panel-wrapper">
+				<button id="throw_error" onClick="OSApp.Utils.does_not_exist('1234'); return false;">Throw error</button>
 				<div class="ui-content" role="main">
 					<div class="ui-grid-a ui-body ui-corner-all info-card noweather">
 						<div class="ui-block-a">

--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -33,3 +33,61 @@ OSApp.Errors.showError = function( msg, dur ) {
 	// Hide after provided delay
 	OSApp.uiState.errorTimeout = setTimeout( function() {$.mobile.loading( "hide" );}, dur );
 };
+
+OSApp.Errors.showErrorModal = function(message, source, lineno, colno, error) {
+	// Create and display a modal with error information
+	const modal = document.createElement('div');
+	modal.innerHTML = `
+	  <div style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; padding: 20px; border: 1px solid #ccc; z-index: 1000;">
+		<h2>${OSApp.Language._('An error occurred')}:</h2>
+		<p>${OSApp.Language._('Message')}: ${message}</p>
+		<p>${OSApp.Language._('File')}: ${source}:${lineno}:${colno}</p>
+		<p style="text-align: right">
+			<button id="ignoreButton">${OSApp.Language._('Ignore')}</button>
+			<button id="createIssueButton">${OSApp.Language._('Report Error')}</button>
+		</p>
+	  </div>
+	`;
+	document.body.appendChild(modal);
+
+	const createIssueButton = document.getElementById('createIssueButton');
+	createIssueButton.addEventListener('click', () => {
+		OSApp.Errors.createGitHubIssue(message, source, lineno, colno, error);
+		document.body.removeChild(modal)
+	});
+
+	const ignoreButton = document.getElementById('ignoreButton');
+	ignoreButton.addEventListener('click', () => {
+		document.body.removeChild(modal)
+	});
+};
+
+OSApp.Errors.createGitHubIssue = function(message, source, lineno, colno, error) {
+	const title = `JavaScript Error: ${message.substring(0, 50)}`; // Shorten the title
+	const body = `
+	## Error Details
+
+	**Message:** ${message}
+	**File:** ${source}:${lineno}:${colno}
+	**Stack Trace:**\n\`\`\`\n${error ? error.stack : 'No stack trace available'}\n\`\`\`
+
+	## User Information
+
+	**User Agent:** ${navigator.userAgent}
+	**Platform:** ${navigator.platform}
+	**Language:** ${navigator.language}
+	**App Version:** TODO!
+	**Firmware Version:** ${OSApp.Firmware.getOSVersion()}
+
+	## Steps to reproduce (if known):
+
+	*(Please describe how to reproduce the error)*
+	`;
+
+	const encodedTitle = encodeURIComponent(title);
+	const encodedBody = encodeURIComponent(body);
+
+	const issueUrl = `https://github.com/OpenSprinkler/OpenSprinkler-App/issues/new?title=${encodedTitle}&body=${encodedBody}`;
+
+	window.open(issueUrl, '_blank'); // Open in a new tab
+};

--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -62,26 +62,48 @@ OSApp.Errors.showErrorModal = function(message, source, lineno, colno, error) {
 	});
 };
 
+OSApp.Errors.formatDeviceInfo = function(deviceInfo) {
+	var markdownString = '';
+
+	for (var key in deviceInfo) {
+	  if (deviceInfo.hasOwnProperty(key)) {
+		var value = deviceInfo[key];
+		if (typeof value === 'boolean') {
+			value = value ? 'Yes' : 'No';
+		}
+
+		if (typeof value !== 'function') {
+			markdownString += `- **${key}**: ${value}\n`;
+		}
+	  }
+	}
+
+	return markdownString;
+};
+
 OSApp.Errors.createGitHubIssue = function(message, source, lineno, colno, error) {
-	const title = `JavaScript Error: ${message.substring(0, 50)}`; // Shorten the title
+	const title = `JavaScript Error: ${message.substring(0, 200)}`;
 	const body = `
-	## Error Details
+## Error Details
 
-	**Message:** ${message}
-	**File:** ${source}:${lineno}:${colno}
-	**Stack Trace:**\n\`\`\`\n${error ? error.stack : 'No stack trace available'}\n\`\`\`
+**Message:** ${message}
+**File:** ${source}:${lineno}:${colno}
+**Stack Trace:**\n\`\`\`\n${error ? error.stack : 'No stack trace available'}\n\`\`\`
 
-	## User Information
+## User Information
 
-	**User Agent:** ${navigator.userAgent}
-	**Platform:** ${navigator.platform}
-	**Language:** ${navigator.language}
-	**App Version:** ${OSApp.uiState.appVersion}
-	**Firmware Version:** ${OSApp.Firmware.getOSVersion()}
+- **User Agent:** ${navigator.userAgent}
+- **Platform:** ${navigator.platform}
+- **Language:** ${navigator.language}
+- **App Version:** ${OSApp.uiState.appVersion}
+- **Firmware Version:** ${OSApp.Firmware.getOSVersion()}
 
-	## Steps to reproduce (if known):
+## Device Information
+${OSApp.Errors.formatDeviceInfo(OSApp.currentDevice)}
 
-	*(Please describe how to reproduce the error)*
+## Steps to reproduce (if known):
+
+*(Please describe how to reproduce the error. Screenshots or a video are much appreciated!)*
 	`;
 
 	const encodedTitle = encodeURIComponent(title);

--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -76,7 +76,7 @@ OSApp.Errors.createGitHubIssue = function(message, source, lineno, colno, error)
 	**User Agent:** ${navigator.userAgent}
 	**Platform:** ${navigator.platform}
 	**Language:** ${navigator.language}
-	**App Version:** TODO!
+	**App Version:** ${OSApp.uiState.appVersion}
 	**Firmware Version:** ${OSApp.Firmware.getOSVersion()}
 
 	## Steps to reproduce (if known):


### PR DESCRIPTION
#### Changes Proposed

- Goal is to improve the generic uncaught exception handling to display a modal for the user with basic info and add the ability to report the error via GitHub issues
- Extend all github workflow actions to set `OSApp.uiState.appVersion` variable
- Refactor about.js to use `OSApp.uiState.appVersion` variable
- Remove about.js steps from all github workflows, due to superseded by `OSApp.uiState.appVersion`
- Add `OSApp.currentDevice` details to issue markdown


#### Demo Video or Screenshots


https://github.com/user-attachments/assets/6dee6b32-c8ff-4182-b4da-fddbfab049ae





