### PR TITLE
WIP: feature(programs): toggle display of disabled programs

### DIFF
--- a/www/css/main.css
+++ b/www/css/main.css
@@ -626,6 +626,19 @@ input[type=number] {
 }
 
 /* Program editor rules */
+.program-disabled {
+	display: none;
+}
+.show-hidden .program-disabled {
+	display: block;
+}
+.disabled-programs-note {
+	display: block;
+}
+.show-hidden .disabled-programs-note {
+	display: none;
+}
+
 .move-up {
     border: none !important;
     float: right;

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -20,11 +20,11 @@ var OSApp = OSApp || {};
 // TODO: add unit tests for each module
 // TODO: move vendor js (jquery, jqm, datatables, etc) to /js/vendor
 
-/* ************** TODO: remove this, it is temporary ***************/
-window.onerror = function( m, s, l, c, e ) {
-	console.error( "*** Uncaught Exception", e );
-	alert( "*** Uncaught exception! " + e );
-	return false;
+window.onerror = function(message, source, lineno, colno, error) {
+	// Catch any uncaught exceptions. Write them to console, show the user a modal to report the error.
+	console.error( "*** Uncaught Exception", {message, source, lineno, colno, error} );
+	OSApp.Errors.showErrorModal(message, source, lineno, colno, error);
+	return true;
 };
 
 // App Constants

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -1665,7 +1665,7 @@ OSApp.Programs.updateProgramHeader = function() {
 	} );
 };
 
-// Make the list of all programs, respecting the options.showHidden setting to toggle disabled program display
+// Make the list of all programs, respecting the "hide disabled" option/waffle setting to toggle visibility of disabled programs
 OSApp.Programs.makeAllPrograms = function() {
 	if ( OSApp.currentSession.controller.programs.pd.length === 0 ) {
 		return "<p class='center'>" + OSApp.Language._( "You have no programs currently added. Tap the Add button on the top right corner to get started." ) + "</p>";
@@ -1682,19 +1682,19 @@ OSApp.Programs.makeAllPrograms = function() {
 		if ( program.en === 0) {
 			numDisabledPrograms++;
 		}
-		console.log("*** makeAllPrograms " + name + " enabled: " + program.en, {program})
 
-		list += "<fieldset id='program-" + i + "' data-role='collapsible'>" + // mellodev class='" + ( program.en === 0 ? "program-disabled " : "" ) + "'>" +
-			"<h3>" +
-			"<a " + ( i > 0 ? "" : "style='visibility:hidden' " ) + "class='hidden ui-btn ui-btn-icon-notext ui-icon-arrow-u ui-btn-corner-all move-up'></a>" +
-			"<a class='ui-btn ui-btn-corner-all program-copy'>" + OSApp.Language._( "copy" ) + "</a>" +
-			"<span class='program-name'>" + name + "</span>" +
-			"</h3>" +
-			"</fieldset>";
+		list += `
+			<fieldset id='program-${i}' data-role='collapsible'>
+				<h3>
+					<a ${( i > 0 ? "" : "style='visibility:hidden' " )} class='hidden ui-btn ui-btn-icon-notext ui-icon-arrow-u ui-btn-corner-all move-up'></a>
+					<a class='ui-btn ui-btn-corner-all program-copy'>${OSApp.Language._( "copy" )}</a>
+					<span class='program-name'>${name}</span>
+				</h3>
+			</fieldset>`;
 	}
 
 	if ( numDisabledPrograms ) {
-		list += "<p class='center disabled-programs-note'>" + numDisabledPrograms + " disabled program(s) hidden. Tap 'Show Disabled' in the footer menu to view</p>";
+		list += "<p class='center disabled-programs-note'>" + numDisabledPrograms + " " + OSApp.Language._( "disabled program(s) hidden. Tap 'Show Disabled' in the footer menu to view" ) + "</p>";
 	}
 
 	return list + "</div>";
@@ -2308,15 +2308,13 @@ OSApp.Programs.submitProgram = function( id ) {
 	$( "#program-" + id ).find( ".hasChanges" ).removeClass( "hasChanges" );
 
 	if ( OSApp.Firmware.checkOSVersion( 210 ) ) {
-		console.log('*** submitProgram');
 		OSApp.Programs.submitProgram21( id );
 	} else {
 		OSApp.Programs.submitProgram183( id );
 	}
 
-	console.log('*** submitProgram calling updateControllerPrograms');
+	// Reload the programs from the controller then redraw the programs list
 	OSApp.Sites.updateControllerPrograms( function() {
-		console.log('*** submitProgram calling trigger programrefresh');
 		$( "#programs" ).trigger( "programrefresh" );
 	} );
 };
@@ -2576,17 +2574,9 @@ OSApp.Programs.submitProgram21 = function( id, ignoreWarning ) {
 			OSApp.Sites.updateControllerPrograms( function() {
 				OSApp.Programs.updateProgramHeader();
 				$( "#program-" + id ).find( ".program-name" ).text( name );
-				// mellodev set the disabled class to update ui need to
-				console.log('*** called cp endpoint');
-				// if ( program.en ) {
-				// 	$( "#program-" + id ).removeClass( "program-disabled" );
-				// } else {
-				// 	$( "#program-" + id ).addClass( "program-disabled" );
-				// }
-			} );
 			OSApp.Errors.showError( OSApp.Language._( "Program has been updated" ) );
 		} );
-	}
+	} );
 };
 
 OSApp.Programs.expandProgram = function( program ) {
@@ -2660,4 +2650,6 @@ OSApp.Programs.expandProgram = function( program ) {
 		} );
 		return false;
 	} );
+}
 };
+

--- a/www/js/modules/sites.js
+++ b/www/js/modules/sites.js
@@ -1066,7 +1066,6 @@ OSApp.Sites.updateControllerPrograms = function( callback ) {
 		} );
 	} else {
 		return OSApp.Firmware.sendToOS( "/jp?pw=", "json" ).done( function( programs ) {
-			console.log('*** sites.js updateControllerPrograms', {old: OSApp.currentSession.controller.programs, new: programs});
 			OSApp.currentSession.controller.programs = programs;
 			callback();
 		} );

--- a/www/js/modules/sites.js
+++ b/www/js/modules/sites.js
@@ -1066,6 +1066,7 @@ OSApp.Sites.updateControllerPrograms = function( callback ) {
 		} );
 	} else {
 		return OSApp.Firmware.sendToOS( "/jp?pw=", "json" ).done( function( programs ) {
+			console.log('*** sites.js updateControllerPrograms', {old: OSApp.currentSession.controller.programs, new: programs});
 			OSApp.currentSession.controller.programs = programs;
 			callback();
 		} );

--- a/www/js/modules/ui-dom.js
+++ b/www/js/modules/ui-dom.js
@@ -338,9 +338,11 @@ OSApp.UIDom.showHomeMenu = ( function() {
 			} else if ( href === "#show-hidden" ) {
 				if ( showHidden ) {
 					$( ".station-hidden" ).hide();
+					$( ".disabled-programs-note" ).show();
 					page.removeClass( "show-hidden" );
 				} else {
 					$( ".station-hidden" ).show();
+					$( ".disabled-programs-note" ).hide();
 					page.addClass( "show-hidden" );
 				}
 			} else if ( href === "#raindelay" ) {


### PR DESCRIPTION
#### Changes Proposed

- Work in progress
- Extend the program display logic so disabled programs are hidden
- When disabled programs are hidden, display a message to the user explaining how many and how to view
- When waffle menu "Show Hidden" is used, display disabled programs
- When a program is saved, collapse the program list item. This prevents an issue when a program changes to disabled
- Extend `OSApp.programs.submitProgram` to properly call `OSApp.Sites.updateControllerPrograms` then trigger a `programrefresh` event. This allows proper hiding/displaying of programs when their enabled flag is changed and saved.
- Extend css with a few classes to allow css engine to hide/display programs with existing `show-hidden` page class logic

#### Demo Video or Screenshots

Please include a short video or screenshot(s) to assist with pr review
