### PR TITLE
feat(error-handler): malformed json error modal

### DIFF
--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -113,3 +113,38 @@ ${OSApp.Errors.formatDeviceInfo(OSApp.currentDevice)}
 
 	window.open(issueUrl, '_blank'); // Open in a new tab
 };
+
+OSApp.Errors.showCorruptedJsonModal = function(badJson, currentSession) {
+	// Create and display a modal prompting user to update firmware
+	let cs = OSApp.Language._('Unknown');
+	OSApp.Storage.get("current_site", function(x) {
+		cs = x?.current_site || OSApp.Language._('Unknown');
+	});
+	console.log("*** showCorruptedJsonModal", {badJson, currentSession, currentSite: cs});
+
+	const modal = document.createElement('div');
+	modal.innerHTML = `
+	  <div style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; padding: 20px; border: 1px solid #ccc; z-index: 1000;">
+		<h2>${OSApp.Language._('Error: Corrupted Response')}</h2>
+		<p>${OSApp.Language._('Uh oh! It looks like your OpenSprinkler controller sent some scrambled data, and that caused the app to stumble. This often happens when the controller\'s firmware is out of date.')}</p>
+		<p><b>${OSApp.Language._('Site Name')}</b>: ${cs}</p>
+		<p>${OSApp.Language._('To get things running smoothly again, we strongly recommend updating your OpenSprinkler firmware. Tap the Guide button below for more information')}</p>
+		<p><b>${OSApp.Language._('Important Note: Updating the firmware will erase your current settings. Use the Recovery Tool to save them beforehand!')}</b></p>
+		<p style="text-align: right;margin: 0 -18px;">
+			<button id="recoveryButton">${OSApp.Language._('Recovery Tool')}</button>
+			<button id="instructionsButton">${OSApp.Language._('Update Guide')}</button>
+		</p>
+	  </div>
+	`;
+	document.body.appendChild(modal);
+
+	const recoveryButton = document.getElementById('recoveryButton');
+	recoveryButton.addEventListener('click', () => {
+		window.open('https://raysfiles.com/os/TestOSLogWithCSV.html', "_blank");
+	});
+
+	const instructionsButton = document.getElementById('instructionsButton');
+	instructionsButton.addEventListener('click', () => {
+		window.open('https://openthings.freshdesk.com/support/solutions/articles/5000381694-opensprinkler-firmware-update-guide-summary-', "_blank");
+	});
+};

--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -125,14 +125,13 @@ OSApp.Errors.showCorruptedJsonModal = function(badJson, currentSession) {
 	const modal = document.createElement('div');
 	modal.innerHTML = `
 	  <div style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; padding: 20px; border: 1px solid #ccc; z-index: 1000;">
-		<h2>${OSApp.Language._('Error: Corrupted Response')}</h2>
-		<p>${OSApp.Language._('Uh oh! It looks like your OpenSprinkler controller sent some scrambled data, and that caused the app to stumble. This often happens when the controller\'s firmware is out of date.')}</p>
+		<h2>${OSApp.Language._('Corrupted Response')}</h2>
+		<p>${OSApp.Language._('The OpenSprinkler controller sent unexpected data, likely due to outdated firmware.')}</p>
 		<p><b>${OSApp.Language._('Site Name')}</b>: ${cs}</p>
-		<p>${OSApp.Language._('To get things running smoothly again, we strongly recommend updating your OpenSprinkler firmware. Tap the Guide button below for more information')}</p>
-		<p><b>${OSApp.Language._('Important Note: Updating the firmware will erase your current settings. Use the Recovery Tool to save them beforehand!')}</b></p>
-		<p style="text-align: right;margin: 0 -18px;">
-			<button id="recoveryButton">${OSApp.Language._('Recovery Tool')}</button>
-			<button id="instructionsButton">${OSApp.Language._('Update Guide')}</button>
+		<p>${OSApp.Language._('To fix this, please update your firmware. Remember to use the "CSV Tool" to save your current settings beforehand!')}</p>
+		<p style="text-align: right">
+			<button id="recoveryButton">${OSApp.Language._('CSV Tool')}</button>
+			<button id="instructionsButton">${OSApp.Language._('Help')}</button>
 		</p>
 	  </div>
 	`;

--- a/www/js/modules/sites.js
+++ b/www/js/modules/sites.js
@@ -929,7 +929,7 @@ OSApp.Sites.newLoad = function() {
 			}
 
 			// Check if the OpenSprinkler can be accessed from the public IP
-			if ( !OSApp.currentSession.local && typeof OSApp.currentSession.controller.settings.eip === "number" ) {
+			if ( !OSApp.currentSession.local && typeof OSApp.currentSession.controller?.settings?.eip === "number" ) {
 				OSApp.Network.checkPublicAccess( OSApp.currentSession.controller.settings.eip );
 			}
 
@@ -1231,6 +1231,8 @@ OSApp.Sites.updateControllerSettings = function( callback ) {
 							OSApp.Sites.handleCorruptedWeatherOptions( wto );
 							//eslint-disable-next-line no-unused-vars
 						} catch ( e ) {
+							// Corrupted JSON returned. Display error modal with fw update links
+							OSApp.Errors.showCorruptedJsonModal( settings, OSApp.currentSession );
 							return false;
 						}
 					}

--- a/www/js/modules/utils.js
+++ b/www/js/modules/utils.js
@@ -158,3 +158,10 @@ OSApp.Utils.isValidOTC = function( token ) {
 OSApp.Utils.flowCountToVolume = function( count ) {
 	return parseFloat( ( count * ( ( OSApp.currentSession.controller.options.fpr1 << 8 ) + OSApp.currentSession.controller.options.fpr0 ) / 100 ).toFixed( 2 ) );
 };
+
+/*
+Returns true when currentSession.controller.settings is populated
+*/
+OSApp.Utils.isSessionValid = function() {
+	return !$.isEmptyObject(OSApp.currentSession?.controller?.settings || {});
+};

--- a/www/js/modules/weather.js
+++ b/www/js/modules/weather.js
@@ -631,6 +631,11 @@ OSApp.Weather.finishWeatherUpdate = function() {
 };
 
 OSApp.Weather.updateWeather = function() {
+	if ( !OSApp.Utils.isSessionValid() ) {
+		console.log("*** updateWeather aborted due to invalid session");
+		return;
+	}
+
 	var now = new Date().getTime();
 
 	if ( OSApp.currentSession.weather && OSApp.currentSession.weather.providedLocation === OSApp.currentSession.controller.settings.loc && now - OSApp.currentSession.weather.lastUpdated < 60 * 60 * 100 ) {


### PR DESCRIPTION
#### Changes Proposed

- Adds a new error modal that is displayed when we detect malformed json returned from the /jc endpoint
- The modal suggests the user update their firmware, with links to the update guide and the settings recovery tool
- 💡 It would be nice to have a wiki guide page for the recovery tool with usage instructions. We could link there instead of to the tool.
- 💡 Would also be nice to offer the user a way to remove the problematic controller from their sites? Currently the app is not usable after displaying the modal.

#### Demo Video or Screenshots

![image](https://github.com/user-attachments/assets/223cdf9b-b337-4096-b980-bdb80d12e13d)




https://github.com/user-attachments/assets/9494bd29-7fff-43a7-ad04-4bda0daaaeda

