### PR TITLE
feat(station-number): display zone number with station name

### DIFF
--- a/www/js/modules/dashboard.js
+++ b/www/js/modules/dashboard.js
@@ -55,8 +55,7 @@ OSApp.Dashboard.displayPage = function() {
 			};
 		},
 		addCard = function( sid ) {
-			var station = OSApp.Stations.getName( sid ),
-				isScheduled = OSApp.Stations.getPID( sid ) > 0,
+			var isScheduled = OSApp.Stations.getPID( sid ) > 0,
 				isRunning = OSApp.Stations.isRunning( sid ),
 				pname = isScheduled ? OSApp.Programs.pidToName( OSApp.Stations.getPID( sid ) ) : "",
 				rem = OSApp.Stations.getRemainingRuntime( sid ),
@@ -75,9 +74,9 @@ OSApp.Dashboard.displayPage = function() {
 
 			cards += "<img src='" + ( hasImage ? "data:image/jpeg;base64," + sites[ currentSite ].images[ sid ] : OSApp.UIDom.getAppURLPath() + "img/placeholder.png" ) + "' />";
 
-			cards += "<p class='station-name center inline-icon' id='station_" + sid + "'>" + station + "</p>";
 
-			cards += "<span class='btn-no-border ui-btn ui-btn-icon-notext ui-corner-all card-icon station-status " +
+			cards += "<p class='station-name center inline-icon' id='station_" + sid + "'>" + OSApp.Stations.getName( sid) + "</p>";
+			cards += "<span class='bno-border ui-btn ui-btn-icon-notext ui-corner-all card-icon station-status " +
 				( isRunning ? "on" : ( isScheduled ? "wait" : "off" ) ) + "'></span>";
 
 			cards += "<span class='btn-no-border ui-btn ui-btn-icon-notext ui-icon-wifi card-icon special-station " +
@@ -385,7 +384,7 @@ OSApp.Dashboard.displayPage = function() {
 
 			select += "<div class='ui-bar-a ui-bar'>" + OSApp.Language._( "Station Name" ) + ":</div>" +
 				"<input class='bold center' data-corners='false' data-wrapper-class='tight stn-name ui-btn' id='stn-name' type='text' value=\"" +
-				name.text() + "\">";
+				OSApp.currentSession.controller.stations.snames[sid] + "\">";
 
 			select += "<button class='changeBackground'>" +
 				( typeof sites[ currentSite ].images[ sid ] !== "string" ? OSApp.Language._( "Add" ) : OSApp.Language._( "Change" ) ) + " " + OSApp.Language._( "Image" ) +
@@ -938,7 +937,7 @@ OSApp.Dashboard.displayPage = function() {
 						card.show().removeClass( "station-hidden" );
 					}
 
-					card.find( "#station_" + sid ).text( OSApp.currentSession.controller.stations.snames[ sid ] );
+					card.find( "#station_" + sid ).text( OSApp.Stations.getName( sid) );
 					card.find( ".special-station" ).removeClass( "hidden" ).addClass( OSApp.Stations.isSpecial( sid ) ? "" : "hidden" );
 					card.find( ".station-status" ).removeClass( "on off wait" ).addClass( isRunning ? "on" : ( isScheduled ? "wait" : "off" ) );
 					if ( OSApp.Stations.isMaster( sid ) ) {

--- a/www/js/modules/logs.js
+++ b/www/js/modules/logs.js
@@ -108,6 +108,8 @@ OSApp.Logs.displayPage = function() {
 					stats.totalCount++;
 				}
 
+
+
 				if ( type === "table" ) {
 					switch ( grouping ) {
 						case "station":
@@ -157,7 +159,7 @@ OSApp.Logs.displayPage = function() {
 					} else {
 						className = "program-" + ( ( pid + 3 ) % 4 );
 						name = OSApp.Programs.pidToName( pid );
-						group = OSApp.currentSession.controller.stations.snames[ station ];
+						group = OSApp.Stations.getName(station);
 						shortname = "S" + ( station + 1 );
 					}
 
@@ -377,7 +379,8 @@ OSApp.Logs.displayPage = function() {
 					groupArray[ i ] += tableHeader;
 
 					for ( k = 0; k < sortedData[ group ].length; k++ ) {
-						var stationName = ( grouping === 'station' ) ? stations[ group ] : stations[ sortedData[ group ][ k ][ 2 ] ];
+						var sid = ( grouping === 'station' ) ? group  : sortedData[group][k][2];
+						var stationName = OSApp.Stations.getName(sid);
 						var runTime = sortedData[ group ][ k ][ 1 ];
 						var startTime = formatTime( sortedData[ group ][ k ][ 0 ], grouping ) ;
 						var endTime = formatTime( sortedData[ group ][ k ][ 3 ], grouping );

--- a/www/js/modules/options.js
+++ b/www/js/modules/options.js
@@ -393,7 +393,7 @@ OSApp.Options.showOptions = function( expandItem ) {
 
 		for ( i = 0; i < OSApp.currentSession.controller.stations.snames.length; i++ ) {
 			list += "<option " + ( ( OSApp.Stations.isMaster( i ) === 1 ) ? "selected" : "" ) + " value='" + ( i + 1 ) + "'>" +
-				OSApp.currentSession.controller.stations.snames[ i ] + "</option>";
+				OSApp.Stations.getName( i ) + "</option>";
 
 			if ( !OSApp.Firmware.checkOSVersion( 214 ) && i === 7 ) {
 				break;
@@ -424,7 +424,7 @@ OSApp.Options.showOptions = function( expandItem ) {
 			"</label><select data-mini='true' id='o37'><option value='0'>" + OSApp.Language._( "None" ) + "</option>";
 
 		for ( i = 0; i < OSApp.currentSession.controller.stations.snames.length; i++ ) {
-			list += "<option " + ( ( OSApp.Stations.isMaster( i ) === 2 ) ? "selected" : "" ) + " value='" + ( i + 1 ) + "'>" + OSApp.currentSession.controller.stations.snames[ i ] +
+			list += "<option " + ( ( OSApp.Stations.isMaster( i ) === 2 ) ? "selected" : "" ) + " value='" + ( i + 1 ) + "'>" + OSApp.Stations.getName(i) +
 				"</option>";
 
 			if ( !OSApp.Firmware.checkOSVersion( 214 ) && i === 7 ) {
@@ -482,6 +482,9 @@ OSApp.Options.showOptions = function( expandItem ) {
 				( ( OSApp.currentSession.controller.options.seq === 1 ) ? "checked='checked'" : "" ) + ">" +
 			OSApp.Language._( "Sequential" ) + "</label>";
 	}
+
+	list += "<label for='showStationNum'><input data-mini='true' class='noselect' id='showStationNum' type='checkbox' " + ( ( localStorage.showStationNum === "true" ) ? "checked='checked'" : "" ) + ">" +
+	OSApp.Language._( "Show Station Number" ) + " " + OSApp.Language._( "(Changes Auto-Saved)" ) + "</label>";
 
 	list += "</fieldset><fieldset data-role='collapsible'" +
 		( typeof expandItem === "string" && expandItem === "weather" ? " data-collapsed='false'" : "" ) + ">" +
@@ -948,6 +951,11 @@ OSApp.Options.showOptions = function( expandItem ) {
 
 	page.find( "#showDisabled" ).on( "change", function() {
 		OSApp.Storage.set( { showDisabled: this.checked } );
+		return false;
+	} );
+
+	page.find( "#showStationNum" ).on( "change", function() {
+		OSApp.Storage.set( { showStationNum: this.checked } );
 		return false;
 	} );
 

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -168,7 +168,7 @@ OSApp.Programs.displayPageManual = function() {
 					}
 				}
 
-				item.text( OSApp.currentSession.controller.stations.snames[ currPos ] );
+				item.text( OSApp.Stations.getName(currPos) );
 
 				if ( OSApp.currentSession.controller.status[ currPos ] ) {
 					item.removeClass( "yellow" ).addClass( "green" );
@@ -996,7 +996,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 							"className":"master",
 							"shortname":"M" + ( mas2 ? "1" : "" ),
 							"group":"Master",
-							"station": sid
+							"station": sid,
 						} );
 					}
 
@@ -1008,7 +1008,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 							"className":"master",
 							"shortname":"M2",
 							"group":"Master 2",
-							"station": sid
+							"station": sid,
 						} );
 					}
 				}
@@ -1037,7 +1037,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 									"className":"master",
 									"shortname":"M" + ( mas2 ? "1" : "" ),
 									"group":"Master",
-									"station": sid
+									"station": sid,
 								} );
 							}
 
@@ -1049,7 +1049,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 									"className":"master",
 									"shortname":"M2",
 									"group":"Master 2",
-									"station": sid
+									"station": sid,
 								} );
 							}
 						}
@@ -1070,7 +1070,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 								"className":"master",
 								"shortname":"M",
 								"group":"Master",
-								"station": sid
+								"station": sid,
 							} );
 						}
 						timeToText( sid, startArray[ sid ], programArray[ sid ], endArray[ sid ], simt );
@@ -1093,7 +1093,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 					"className":"master",
 					"shortname":"M",
 					"group":"Master",
-					"station": sid
+					"station": sid,
 				} );
 			}
 		}
@@ -1124,8 +1124,8 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 			"content":pname,
 			"pid": pid - 1,
 			"shortname":"S" + ( sid + 1 ),
-			"group": OSApp.currentSession.controller.stations.snames[ sid ],
-			"station": sid
+			"group": OSApp.Stations.getName(sid),
+			"station": sid,
 		} );
 	};
 
@@ -1464,6 +1464,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 			var stn = $( this );
 			var name = shortnames[ stn.text() ];
 			stn.attr( "data-shortname", name );
+
 		} );
 
 		page.find( ".timeline-groups-axis" ).children().first().html( "<div class='timeline-axis-text center dayofweek' data-shortname='" +
@@ -1841,7 +1842,7 @@ OSApp.Programs.makeProgram183 = function( n, isCopy ) {
 		list += "<label for='station_" + j + "-" + id + "'><input " +
 			( OSApp.Stations.isDisabled( j ) ? "data-wrapper-class='station-hidden hidden' " : "" ) +
 			"data-mini='true' type='checkbox' " + ( ( ( typeof setStations !== "undefined" ) && setStations[ j ] ) ? "checked='checked'" : "" ) +
-			" name='station_" + j + "-" + id + "' id='station_" + j + "-" + id + "'>" + OSApp.currentSession.controller.stations.snames[ j ] + "</label>";
+			" name='station_" + j + "-" + id + "' id='station_" + j + "-" + id + "'>" + OSApp.Stations.getName(j) + "</label>";
 	}
 
 	list += "</fieldset>";
@@ -2104,13 +2105,13 @@ OSApp.Programs.makeProgram21 = function( n, isCopy ) {
 	for ( j = 0; j < OSApp.currentSession.controller.stations.snames.length; j++ ) {
 		if ( OSApp.Stations.isMaster( j ) ) {
 			list += "<div class='ui-field-contain duration-input" + ( OSApp.Stations.isDisabled( j ) ? " station-hidden" + hideDisabled : "" ) + "'>" +
-				"<label for='station_" + j + "-" + id + "'>" + OSApp.currentSession.controller.stations.snames[ j ] + ":</label>" +
+				"<label for='station_" + j + "-" + id + "'>" + OSApp.Stations.getName(j) + ":</label>" +
 				"<button disabled='true' data-mini='true' name='station_" + j + "-" + id + "' id='station_" + j + "-" + id + "' value='0'>" +
 				OSApp.Language._( "Master" ) + "</button></div>";
 		} else {
 			time = program.stations[ j ] || 0;
 			list += "<div class='ui-field-contain duration-input" + ( OSApp.Stations.isDisabled( j ) ? " station-hidden" + hideDisabled : "" ) + "'>" +
-				"<label for='station_" + j + "-" + id + "'>" + OSApp.currentSession.controller.stations.snames[ j ] + ":</label>" +
+				"<label for='station_" + j + "-" + id + "'>" + OSApp.Stations.getName(j) + ":</label>" +
 				"<button " + ( time > 0 ? "class='green' " : "" ) + "data-mini='true' name='station_" + j + "-" + id + "' " +
 					"id='station_" + j + "-" + id + "' value='" + time + "'>" + OSApp.Dates.getDurationText( time ) + "</button></div>";
 		}
@@ -2280,7 +2281,7 @@ OSApp.Programs.makeProgram21 = function( n, isCopy ) {
 	// Handle all station duration inputs
 	page.find( "[id^=station_]" ).on( "click", function() {
 		var dur = $( this ),
-			name = OSApp.currentSession.controller.stations.snames[ dur.attr( "id" ).split( "_" )[ 1 ].split( "-" )[ 0 ] ];
+			name = OSApp.Stations.getName( dur.attr( "id" ).split( "_" )[ 1 ].split( "-" )[ 0 ] );
 
 		OSApp.UIDom.showDurationBox( {
 			seconds: dur.val(),

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -389,14 +389,14 @@ OSApp.Programs.displayPageRunOnce = function() {
 		}
 		quickPick += "</select>";
 		list += quickPick + "<form>";
-		$.each( OSApp.currentSession.controller.stations.snames, function( i, station ) {
+		$.each( OSApp.currentSession.controller.stations.snames, function( i ) {
 			if ( OSApp.Stations.isMaster( i ) ) {
 				list += "<div class='ui-field-contain duration-input" + ( OSApp.Stations.isDisabled( i ) ? " station-hidden' style='display:none" : "" ) + "'>" +
-					"<label for='zone-" + i + "'>" + station + ":</label>" +
+					"<label for='zone-" + i + "'>" + OSApp.Stations.getName(i) + ":</label>" +
 					"<button disabled='true' data-mini='true' name='zone-" + i + "' id='zone-" + i + "' value='0'>Master</button></div>";
 			} else {
 				list += "<div class='ui-field-contain duration-input" + ( OSApp.Stations.isDisabled( i ) ? " station-hidden' style='display:none" : "" ) + "'>" +
-					"<label for='zone-" + i + "'>" + station + ":</label>" +
+					"<label for='zone-" + i + "'>" + OSApp.Stations.getName(i) + ":</label>" +
 					"<button data-mini='true' name='zone-" + i + "' id='zone-" + i + "' value='0'>0s</button></div>";
 			}
 		} );

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -996,7 +996,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 							"className":"master",
 							"shortname":"M" + ( mas2 ? "1" : "" ),
 							"group":"Master",
-							"station": sid,
+							"station": sid
 						} );
 					}
 
@@ -1008,7 +1008,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 							"className":"master",
 							"shortname":"M2",
 							"group":"Master 2",
-							"station": sid,
+							"station": sid
 						} );
 					}
 				}
@@ -1037,7 +1037,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 									"className":"master",
 									"shortname":"M" + ( mas2 ? "1" : "" ),
 									"group":"Master",
-									"station": sid,
+									"station": sid
 								} );
 							}
 
@@ -1049,7 +1049,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 									"className":"master",
 									"shortname":"M2",
 									"group":"Master 2",
-									"station": sid,
+									"station": sid
 								} );
 							}
 						}
@@ -1070,7 +1070,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 								"className":"master",
 								"shortname":"M",
 								"group":"Master",
-								"station": sid,
+								"station": sid
 							} );
 						}
 						timeToText( sid, startArray[ sid ], programArray[ sid ], endArray[ sid ], simt );
@@ -1093,7 +1093,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 					"className":"master",
 					"shortname":"M",
 					"group":"Master",
-					"station": sid,
+					"station": sid
 				} );
 			}
 		}
@@ -1125,7 +1125,7 @@ OSApp.Programs.displayPagePreviewPrograms = function() {
 			"pid": pid - 1,
 			"shortname":"S" + ( sid + 1 ),
 			"group": OSApp.Stations.getName(sid),
-			"station": sid,
+			"station": sid
 		} );
 	};
 

--- a/www/js/modules/stations.js
+++ b/www/js/modules/stations.js
@@ -36,7 +36,22 @@ OSApp.Stations.getNumberProgramStatusOptions = function() {
 };
 
 OSApp.Stations.getName = function( sid ) {
-	return OSApp.currentSession.controller.stations.snames[ sid ];
+	var result = sid;
+	if (!OSApp.currentSession.controller?.stations?.snames || OSApp.currentSession.controller?.stations?.snames.length < sid)
+	{
+		return result;
+
+	}
+
+	result = OSApp.currentSession.controller.stations.snames[ sid ];
+
+	OSApp.Storage.get( "showStationNum", function( data ) {
+		if ( data.showStationNum && data.showStationNum === "true" ) {
+			result += ` (S${sid + 1})`;
+		}
+	});
+
+	return result;
 };
 
 OSApp.Stations.setName = function( sid, value ) {

--- a/www/js/modules/stations.js
+++ b/www/js/modules/stations.js
@@ -40,7 +40,6 @@ OSApp.Stations.getName = function( sid ) {
 	if (!OSApp.currentSession.controller?.stations?.snames || OSApp.currentSession.controller?.stations?.snames.length < sid)
 	{
 		return result;
-
 	}
 
 	result = OSApp.currentSession.controller.stations.snames[ sid ];

--- a/www/js/modules/status.js
+++ b/www/js/modules/status.js
@@ -243,7 +243,7 @@ OSApp.Status.checkStatus = function() {
 		pname = OSApp.Programs.pidToName( lrpid );
 
 		OSApp.Status.changeStatus( 0, "transparent", "<p class='running-text smaller center pointer'>" + pname + " " + OSApp.Language._( "last ran station" ) + " " +
-			OSApp.currentSession.controller.stations.snames[ OSApp.currentSession.controller.settings.lrun[ 0 ] ] + " " + OSApp.Language._( "for" ) + " " + ( lrdur / 60 >> 0 ) + "m " + ( lrdur % 60 ) + "s " +
+		OSApp.Stations.getName( OSApp.currentSession.controller.settings.lrun[ 0 ] ) + " " + OSApp.Language._( "for" ) + " " + ( lrdur / 60 >> 0 ) + "m " + ( lrdur % 60 ) + "s " +
 			OSApp.Language._( "on" ) + " " + OSApp.Dates.dateToString( new Date( ( OSApp.currentSession.controller.settings.lrun[ 3 ] - lrdur ) * 1000 ) ) + "</p>", OSApp.UIDom.goHome );
 		return;
 	}


### PR DESCRIPTION
#### Changes Proposed

- Resolves issue #215 
- Displays station/zone number next to station name everywhere station name is displayed (dashboard, preview programs, log table, log timeline, edit program, edit station, footer status)
- Controlled by a new option `showStationNumber` which is stored in local storage
- Refactors many places where station name is retrieved to use `Stations.getName(stationId)` rather than directly reading the `currentSession.controller.stations.snames` array

#### Demo Video or Screenshots


https://github.com/user-attachments/assets/7c6136bc-0758-4333-95d7-581e3516f4b7


