### PR TITLE
fix(weather): use elvis operator rather than early return

### DIFF
--- a/www/js/modules/weather.js
+++ b/www/js/modules/weather.js
@@ -662,14 +662,9 @@ OSApp.Weather.updateWeather = function() {
 
 	OSApp.UIDom.showLoading( "#weather" );
 
-	if ( !OSApp.Firmware.checkOSVersion( 215 ) ) {
-		// controller.settings.wto object is only defined when fw >= 2.1.5
-		return;
-	}
-
-	const provider = OSApp.currentSession.controller.settings.wto.provider;
-	const key = OSApp.currentSession.controller.settings.wto.key;
-	const pws = OSApp.currentSession.controller.settings.wto.pws;
+	const provider = OSApp.currentSession.controller.settings.wto?.provider;
+	const key = OSApp.currentSession.controller.settings.wto?.key;
+	const pws = OSApp.currentSession.controller.settings.wto?.pws;
 
 	let url = OSApp.currentSession.weatherServerUrl + "/weatherData?loc=" +
 	encodeURIComponent( OSApp.currentSession.controller.settings.loc );

--- a/www/js/modules/weather.js
+++ b/www/js/modules/weather.js
@@ -758,17 +758,12 @@ OSApp.Weather.updateWeatherBox = function() {
 };
 
 OSApp.Weather.showForecast = function() {
-	if ( !OSApp.Firmware.checkOSVersion( 215 )) {
-		// wto requires fw >= 2.1.5
-		return;
-	}
-
 	var page = $( "<div data-role='page' id='forecast'>" +
 			"<div class='ui-content' role='main'>" +
 				"<ul data-role='listview' data-inset='true'>" +
 					OSApp.Weather.makeForecast() +
 				"</ul>" +
-				OSApp.Weather.makeAttribution( OSApp.currentSession.controller.settings.wto.provider || OSApp.currentSession.weather.wp || OSApp.currentSession.weather.weatherProvider ) +
+				OSApp.Weather.makeAttribution( OSApp.currentSession.controller.settings.wto?.provider || OSApp.currentSession.weather.wp || OSApp.currentSession.weather.weatherProvider ) +
 			"</div>" +
 		"</div>" );
 


### PR DESCRIPTION
#### Changes Proposed

- Resolves request to use elvis operators rather than early return
- Allows weather component to be displayed properly while preventing crashes with older fw controllers

#### Demo Video or Screenshots

Please include a short video or screenshot(s) to assist with pr review
