### PR TITLE
fix(errors): remove gh create issue button, add ignore all button

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -95,6 +95,7 @@ OSApp.uiState = {
 	errorTimeout: undefined,
 	goingBack: false,
 	is24Hour: false,
+	ignoreAllErrors: false, // User can ignore all errors, preventing the error modal from appearing
 	groupView: false,
 	sortByStationName: false,
 	language: undefined,

--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -34,7 +34,13 @@ OSApp.Errors.showError = function( msg, dur ) {
 	OSApp.uiState.errorTimeout = setTimeout( function() {$.mobile.loading( "hide" );}, dur );
 };
 
-OSApp.Errors.showErrorModal = function(message, source, lineno, colno, error) {
+OSApp.Errors.debugThrowException = function() {
+	// Debug method to create an uncaught exception, used for testing the error modal
+	console.log("*** debugThrowException called", {uiState: OSApp.uiState});
+	console.log(OSApp.uiState.this.does.not.exist);
+}
+
+OSApp.Errors.showErrorModal = function(message, source, lineno, colno/*, error*/) {
 	if ( OSApp.uiState.ignoreAllErrors ) {
 		// Return early if the user has previously clicked ignore all for this session
 		return;
@@ -59,18 +65,20 @@ OSApp.Errors.showErrorModal = function(message, source, lineno, colno, error) {
 	`;
 	document.body.appendChild(modal);
 
+	/* Report issue button
 	const createIssueButton = document.getElementById('createIssueButton');
 	createIssueButton.addEventListener('click', () => {
 		OSApp.Errors.createGitHubIssue(message, source, lineno, colno, error);
 		document.body.removeChild(modal)
 	});
+	*/
 
 	const ignoreButton = document.getElementById('ignoreButton');
 	ignoreButton.addEventListener('click', () => {
 		document.body.removeChild(modal)
 	});
 
-	const ignoreAllButton = document.getElementById('ignoreButton');
+	const ignoreAllButton = document.getElementById('ignoreAllButton');
 	ignoreAllButton.addEventListener('click', () => {
 		OSApp.uiState.ignoreAllErrors = true;
 		document.body.removeChild(modal)

--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -43,8 +43,6 @@ OSApp.Errors.showErrorModal = function(message, source, lineno, colno/*, error*/
 	// Create and display a modal with error information
 	const modal = document.createElement('div');
 
-	// Report issue button:
-	// <button id="createIssueButton">${OSApp.Language._('Report Error')}</button>
 
 	modal.innerHTML = `
 	  <div style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; padding: 20px; border: 1px solid #ccc; z-index: 1000;">
@@ -58,14 +56,6 @@ OSApp.Errors.showErrorModal = function(message, source, lineno, colno/*, error*/
 	  </div>
 	`;
 	document.body.appendChild(modal);
-
-	/* Report issue button
-	const createIssueButton = document.getElementById('createIssueButton');
-	createIssueButton.addEventListener('click', () => {
-		OSApp.Errors.createGitHubIssue(message, source, lineno, colno, error);
-		document.body.removeChild(modal)
-	});
-	*/
 
 	const ignoreButton = document.getElementById('ignoreButton');
 	ignoreButton.addEventListener('click', () => {

--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -35,8 +35,17 @@ OSApp.Errors.showError = function( msg, dur ) {
 };
 
 OSApp.Errors.showErrorModal = function(message, source, lineno, colno, error) {
+	if ( OSApp.uiState.ignoreAllErrors ) {
+		// Return early if the user has previously clicked ignore all for this session
+		return;
+	}
+
 	// Create and display a modal with error information
 	const modal = document.createElement('div');
+
+	// Report issue button:
+	// <button id="createIssueButton">${OSApp.Language._('Report Error')}</button>
+
 	modal.innerHTML = `
 	  <div style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; padding: 20px; border: 1px solid #ccc; z-index: 1000;">
 		<h2>${OSApp.Language._('An error occurred')}:</h2>
@@ -44,7 +53,7 @@ OSApp.Errors.showErrorModal = function(message, source, lineno, colno, error) {
 		<p>${OSApp.Language._('File')}: ${source}:${lineno}:${colno}</p>
 		<p style="text-align: right">
 			<button id="ignoreButton">${OSApp.Language._('Ignore')}</button>
-			<button id="createIssueButton">${OSApp.Language._('Report Error')}</button>
+			<button id="ignoreAllButton">${OSApp.Language._('Ignore All')}</button>
 		</p>
 	  </div>
 	`;
@@ -58,6 +67,12 @@ OSApp.Errors.showErrorModal = function(message, source, lineno, colno, error) {
 
 	const ignoreButton = document.getElementById('ignoreButton');
 	ignoreButton.addEventListener('click', () => {
+		document.body.removeChild(modal)
+	});
+
+	const ignoreAllButton = document.getElementById('ignoreButton');
+	ignoreAllButton.addEventListener('click', () => {
+		OSApp.uiState.ignoreAllErrors = true;
 		document.body.removeChild(modal)
 	});
 };

--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -34,12 +34,6 @@ OSApp.Errors.showError = function( msg, dur ) {
 	OSApp.uiState.errorTimeout = setTimeout( function() {$.mobile.loading( "hide" );}, dur );
 };
 
-OSApp.Errors.debugThrowException = function() {
-	// Debug method to create an uncaught exception, used for testing the error modal
-	console.log("*** debugThrowException called", {uiState: OSApp.uiState});
-	console.log(OSApp.uiState.this.does.not.exist);
-}
-
 OSApp.Errors.showErrorModal = function(message, source, lineno, colno/*, error*/) {
 	if ( OSApp.uiState.ignoreAllErrors ) {
 		// Return early if the user has previously clicked ignore all for this session


### PR DESCRIPTION
#### Changes Proposed

- Temporarily remove the gh create issue button until we can figure out how to get full stack traces sent up
- Adds an  `Ignore All` button which will update the app session (uiState.ignoreAllErrors) to prevent the modal appearing again.
- Ignore All is reset each time the app is launched.

#### Demo Video or Screenshots


https://github.com/user-attachments/assets/70aeaf95-a73a-464e-a81e-97f522990ef5


