### PR TITLE
Fix metric/time settings not loading

### DIFF
--- a/www/js/modules/ui-dom.js
+++ b/www/js/modules/ui-dom.js
@@ -21,9 +21,15 @@ OSApp.UIDom = OSApp.UIDom || {};
 
 // App entry point
 OSApp.UIDom.launchApp = function() {
-	Number.prototype.clamp = function( min, max ) {
-		return Math.min( Math.max( this, min ), max );
-	};
+       // Load any stored local settings immediately since the `mobileinit`
+       // event may fire before this script is executed
+       if ( OSApp.Storage && typeof OSApp.Storage.loadLocalSettings === "function" ) {
+               OSApp.Storage.loadLocalSettings();
+       }
+
+       Number.prototype.clamp = function( min, max ) {
+               return Math.min( Math.max( this, min ), max );
+       };
 
 	if ( "serviceWorker" in navigator ) {
 		window.addEventListener( "load", function() {


### PR DESCRIPTION
## Summary
- ensure metric and 24-hour settings load regardless of `mobileinit` timing

## Testing
- `npm test` *(fails: ChromeHeadless not found)*