### PR TITLE
Append GitVersion to workflow run name

### DIFF
--- a/.github/actions/set-run-name/action.yml
+++ b/.github/actions/set-run-name/action.yml
@@ -1,0 +1,21 @@
+name: 'Set workflow run name'
+description: 'Update the workflow run name to include the provided version'
+inputs:
+  version:
+    description: 'Version number to append to the workflow run name'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Update run name
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const version = '${{ inputs.version }}';
+          await github.request('PATCH /repos/{owner}/{repo}/actions/runs/{run_id}', {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+            name: `${context.workflow} - ${version}`,
+          });

--- a/.github/workflows/app-store-connect.yml
+++ b/.github/workflows/app-store-connect.yml
@@ -65,6 +65,11 @@ jobs:
         with:
           useConfigFile: false
 
+      - name: Append version to run name
+        uses: ./.github/actions/set-run-name
+        with:
+          version: ${{ steps.gitversion.outputs.semVer }}
+
       - name: Update package.json version
         run: |
           sed -i.bak "s|\"version\": \"[0-9\.]*\"|\"version\": \"${{ steps.gitversion.outputs.semVer }}\"|" package.json

--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -42,6 +42,11 @@ jobs:
         with:
           useConfigFile: false
 
+      - name: Append version to run name
+        uses: ./.github/actions/set-run-name
+        with:
+          version: ${{ steps.gitversion.outputs.semVer }}
+
       - name: Update package.json version
         run: |
           sed -i.bak "s|\"version\": \"[0-9\.]*\"|\"version\": \"${{ steps.gitversion.outputs.semVer }}\"|" package.json

--- a/.github/workflows/google-play.yml
+++ b/.github/workflows/google-play.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           useConfigFile: false
 
+      - name: Append version to run name
+        uses: ./.github/actions/set-run-name
+        with:
+          version: ${{ steps.gitversion.outputs.semVer }}
+
       - name: Update package.json Version
         run: |
           sed -i.bak "s|\"version\": \"[0-9\.]*\"|\"version\": \"${{ steps.gitversion.outputs.semVer }}\"|" package.json

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           useConfigFile: false
 
+      - name: Append version to run name
+        uses: ./.github/actions/set-run-name
+        with:
+          version: ${{ steps.gitversion.outputs.semVer }}
+
       - name: Tag repository
         env:
           TAG: ${{ steps.gitversion.outputs.semVer }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v3.0.0
+        with:
+          versionSpec: "5.x"
+
+      - name: Run GitVersion
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v3.0.0
+        with:
+          useConfigFile: false
+
+      - name: Append version to run name
+        uses: ./.github/actions/set-run-name
+        with:
+          version: ${{ steps.gitversion.outputs.semVer }}
+
       - name: Cache Dependencies
         id: cache_npm
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- add a reusable composite action to append GitVersion output to run name
- update all workflows to call the composite action

## Testing
- `npm test` *(fails: No binary for ChromeHeadless)*


------
https://chatgpt.com/codex/tasks/task_e_683ae8d8de30832c9a93d5afdf935224