### PR TITLE
Remove error modal

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -20,12 +20,6 @@ var OSApp = OSApp || {};
 // TODO: add unit tests for each module
 // TODO: move vendor js (jquery, jqm, datatables, etc) to /js/vendor
 
-window.onerror = function(message, source, lineno, colno, error) {
-	// Catch any uncaught exceptions. Write them to console, show the user a modal to report the error.
-	console.error( "*** Uncaught Exception", {message, source, lineno, colno, error} );
-	OSApp.Errors.showErrorModal(message, source, lineno, colno, error);
-	return true;
-};
 
 // App Constants
 OSApp.Constants = {
@@ -95,7 +89,6 @@ OSApp.uiState = {
 	errorTimeout: undefined,
 	goingBack: false,
 	is24Hour: false,
-	ignoreAllErrors: false, // User can ignore all errors, preventing the error modal from appearing
 	groupView: false,
 	sortByStationName: false,
 	language: undefined,

--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -34,40 +34,6 @@ OSApp.Errors.showError = function( msg, dur ) {
 	OSApp.uiState.errorTimeout = setTimeout( function() {$.mobile.loading( "hide" );}, dur );
 };
 
-OSApp.Errors.showErrorModal = function(message, source, lineno, colno/*, error*/) {
-	if ( OSApp.uiState.ignoreAllErrors ) {
-		// Return early if the user has previously clicked ignore all for this session
-		return;
-	}
-
-	// Create and display a modal with error information
-	const modal = document.createElement('div');
-
-
-	modal.innerHTML = `
-	  <div style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; padding: 20px; border: 1px solid #ccc; z-index: 1000;">
-		<h2>${OSApp.Language._('An error occurred')}:</h2>
-		<p>${OSApp.Language._('Message')}: ${message}</p>
-		<p>${OSApp.Language._('File')}: ${source}:${lineno}:${colno}</p>
-		<p style="text-align: right">
-			<button id="ignoreButton">${OSApp.Language._('Ignore')}</button>
-			<button id="ignoreAllButton">${OSApp.Language._('Ignore All')}</button>
-		</p>
-	  </div>
-	`;
-	document.body.appendChild(modal);
-
-	const ignoreButton = document.getElementById('ignoreButton');
-	ignoreButton.addEventListener('click', () => {
-		document.body.removeChild(modal)
-	});
-
-	const ignoreAllButton = document.getElementById('ignoreAllButton');
-	ignoreAllButton.addEventListener('click', () => {
-		OSApp.uiState.ignoreAllErrors = true;
-		document.body.removeChild(modal)
-	});
-};
 
 OSApp.Errors.formatDeviceInfo = function(deviceInfo) {
 	var markdownString = '';
@@ -88,38 +54,6 @@ OSApp.Errors.formatDeviceInfo = function(deviceInfo) {
 	return markdownString;
 };
 
-OSApp.Errors.createGitHubIssue = function(message, source, lineno, colno, error) {
-	const title = `JavaScript Error: ${message.substring(0, 200)}`;
-	const body = `
-## Error Details
-
-**Message:** ${message}
-**File:** ${source}:${lineno}:${colno}
-**Stack Trace:**\n\`\`\`\n${error ? error.stack : 'No stack trace available'}\n\`\`\`
-
-## User Information
-
-- **User Agent:** ${navigator.userAgent}
-- **Platform:** ${navigator.platform}
-- **Language:** ${navigator.language}
-- **App Version:** ${OSApp.uiState.appVersion}
-- **Firmware Version:** ${OSApp.Firmware.getOSVersion()}
-
-## Device Information
-${OSApp.Errors.formatDeviceInfo(OSApp.currentDevice)}
-
-## Steps to reproduce (if known):
-
-*(Please describe how to reproduce the error. Screenshots or a video are much appreciated!)*
-	`;
-
-	const encodedTitle = encodeURIComponent(title);
-	const encodedBody = encodeURIComponent(body);
-
-	const issueUrl = `https://github.com/OpenSprinkler/OpenSprinkler-App/issues/new?title=${encodedTitle}&body=${encodedBody}`;
-
-	window.open(issueUrl, '_blank'); // Open in a new tab
-};
 
 OSApp.Errors.showCorruptedJsonModal = function(badJson, currentSession) {
 	// Create and display a modal prompting user to update firmware

--- a/www/js/modules/errors.js
+++ b/www/js/modules/errors.js
@@ -35,26 +35,6 @@ OSApp.Errors.showError = function( msg, dur ) {
 };
 
 
-OSApp.Errors.formatDeviceInfo = function(deviceInfo) {
-	var markdownString = '';
-
-	for (var key in deviceInfo) {
-	  if (deviceInfo.hasOwnProperty(key)) {
-		var value = deviceInfo[key];
-		if (typeof value === 'boolean') {
-			value = value ? 'Yes' : 'No';
-		}
-
-		if (typeof value !== 'function') {
-			markdownString += `- **${key}**: ${value}\n`;
-		}
-	  }
-	}
-
-	return markdownString;
-};
-
-
 OSApp.Errors.showCorruptedJsonModal = function(badJson, currentSession) {
 	// Create and display a modal prompting user to update firmware
 	let cs = OSApp.Language._('Unknown');


### PR DESCRIPTION
## Summary
- drop global `window.onerror` handler
- remove `ignoreAllErrors` state and error modal functions

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_683b06526fcc832cab1669df1bd159ae