### PR TITLE
Add Cloudflare cache purge after Firebase deploy

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -97,3 +97,23 @@ jobs:
             'opensprinkler-devui'
             ) || 'opensprinkler-devui' }}
           channelId: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'live' || '' }}
+
+      - name: Purge Cloudflare Cache
+        if: secrets.CF_ZONE_ID != '' && secrets.CLOUDFLARE_EMAIL != '' && secrets.CLOUDFLARE_API_KEY != ''
+        env:
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+          ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'dev' }}
+        run: |
+          ENV_NAME="${ENVIRONMENT}"
+          if [ "$ENV_NAME" = "prod" ]; then
+            HOST="ui.opensprinkler.com"
+          else
+            HOST="${ENV_NAME}ui.opensprinkler.com"
+          fi
+          curl https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache \
+            -H "Content-Type: application/json" \
+            -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
+            -H "X-Auth-Key: ${CLOUDFLARE_API_KEY}" \
+            --data "{\"hosts\": [\"${HOST}\"]}"


### PR DESCRIPTION
## Summary
- purge Cloudflare cache using Cloudflare email and API key after Firebase Hosting deploy
- purge target host derived from workflow environment

## Testing
- `npx grunt`
- `npm test` *(fails: No binary for ChromeHeadless browser on your platform)*


------
https://chatgpt.com/codex/tasks/task_e_683c56665a34832cbf17e5fb6fffabbf