### PR TITLE
Add unified URL field

### DIFF
--- a/www/locale/messages_en.po
+++ b/www/locale/messages_en.po
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Change Name"
 msgstr ""
 
-msgid "Change IP"
+msgid "Change URL"
 msgstr ""
 
 msgid "Change Token"
@@ -1717,7 +1717,7 @@ msgstr ""
 msgid "OpenThings Cloud"
 msgstr ""
 
-msgid "Open Sprinkler IP:"
+msgid "Open Sprinkler URL:"
 msgstr ""
 
 msgid "OpenThings Token"


### PR DESCRIPTION
## Summary
- replace IP and Use SSL fields with a single URL field
- migrate existing configuration to new os_url field
- update translations for the new URL label

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_683dfcaa60f8832cbfd330de0c724f04