### PR TITLE
Fix localStorage namespace for reverse proxy

### DIFF
--- a/www/js/home.js
+++ b/www/js/home.js
@@ -1,4 +1,4 @@
-/*global $, ver, ipas, XDomainRequest, ActiveXObject, md5 */
+/*global $, ver, ipas, XDomainRequest, ActiveXObject, md5, OSApp */
 
 /* OpenSprinkler App
  * Copyright (C) 2015 - present, Samer Albahra. All rights reserved.
@@ -152,10 +152,10 @@ window.currLocal = true;
 						if ( loadedScripts === totalScripts ) {
 							// Once all scripts loaded, insert main.js
 							insertScript( assetLocation + "js/main.js", function () {
-								try {
-									localStorage.setItem( "testQuota", "true" );
-									localStorage.removeItem( "testQuota" );
-									init();
+                                                                try {
+                                                                        OSApp.Storage.setItemSync( "testQuota", "true" );
+                                                                        OSApp.Storage.removeItemSync( "testQuota" );
+                                                                        init();
 								} catch ( err ) {
 									if ( err.code === 22 ) {
 										document.body.innerHTML = "<div class='spinner'><div class='logo'></div>" +
@@ -238,8 +238,8 @@ window.currLocal = true;
 				document.title = "Loading...";
 
 				// Inject site information to storage so Application loads current device
-				localStorage.setItem( "sites", JSON.stringify( sites ) );
-				localStorage.setItem( "current_site", currentSite );
+                                OSApp.Storage.setItemSync( "sites", JSON.stringify( sites ) );
+                                OSApp.Storage.setItemSync( "current_site", currentSite );
 				finishInit();
 			},
 			wrongPassword = function() {
@@ -257,7 +257,7 @@ window.currLocal = true;
 						"<div class='logo'></div><span class='feedback'>Unable to load UI</span>" +
 					"</div>" );
 			},
-			sites = JSON.parse( localStorage.getItem( "sites" ) ),
+                        sites = JSON.parse( OSApp.Storage.getItemSync( "sites" ) ),
 			loader;
 
 		// Fix to allow CORS ajax requests to work on IE8 and 9

--- a/www/js/modules/options.js
+++ b/www/js/modules/options.js
@@ -390,10 +390,12 @@ OSApp.Options.showOptions = function( expandItem ) {
        list += "</div>";
 
        list += "<div data-role='controlgroup' data-type='horizontal' style='text-align:center'>";
-               list += "<label for='showDisabled'><input data-mini='true' class='noselect' id='showDisabled' type='checkbox' " + ( ( localStorage.showDisabled === "true" ) ? "checked='checked'" : "" ) + ">" +
+               var showDisabled = OSApp.Storage.getItemSync( "showDisabled" ) === "true";
+               var showStationNum = OSApp.Storage.getItemSync( "showStationNum" ) === "true";
+               list += "<label for='showDisabled'><input data-mini='true' class='noselect' id='showDisabled' type='checkbox' " + ( showDisabled ? "checked='checked'" : "" ) + ">" +
                        OSApp.Language._( "Show Disabled" ) + "</label>";
 
-               list += "<label for='showStationNum'><input data-mini='true' class='noselect' id='showStationNum' type='checkbox' " + ( ( localStorage.showStationNum === "true" ) ? "checked='checked'" : "" ) + ">" +
+               list += "<label for='showStationNum'><input data-mini='true' class='noselect' id='showStationNum' type='checkbox' " + ( showStationNum ? "checked='checked'" : "" ) + ">" +
                        OSApp.Language._( "Show Station Number" ) + "</label>";
        list += "</div>";
 

--- a/www/js/modules/storage.js
+++ b/www/js/modules/storage.js
@@ -15,52 +15,88 @@
 var OSApp = OSApp || {};
 OSApp.Storage = OSApp.Storage || {};
 
+// Prefix to namespace localStorage keys by path. This allows the app to be
+// served from different URLs under the same origin without clobbering each
+// other's storage.
+OSApp.Storage.prefix = ( function() {
+       var path = window.location.pathname
+               .replace(/\/index\.html$/, "")
+               .replace(/\/$/, "");
+       return path ? path + ":" : "";
+} )();
+
+OSApp.Storage._key = function( key ) {
+       return OSApp.Storage.prefix + key;
+};
+
+OSApp.Storage.getItemSync = function( key ) {
+       var value = localStorage.getItem( OSApp.Storage._key( key ) );
+       if ( value === null && OSApp.Storage.prefix ) {
+               value = localStorage.getItem( key );
+       }
+       return value;
+};
+
+OSApp.Storage.setItemSync = function( key, value ) {
+       localStorage.setItem( OSApp.Storage._key( key ), value );
+       if ( OSApp.Storage.prefix ) {
+               localStorage.removeItem( key );
+       }
+};
+
+OSApp.Storage.removeItemSync = function( key ) {
+       localStorage.removeItem( OSApp.Storage._key( key ) );
+       if ( OSApp.Storage.prefix ) {
+               localStorage.removeItem( key );
+       }
+};
+
 // Functions
 OSApp.Storage.get = function( query, callback ) {
-	callback = callback || function() {};
-	var data = {},
-		i;
+       callback = callback || function() {};
+       var data = {},
+               i;
 
-	if ( typeof query === "string" ) {
-		query = [ query ];
-	}
+       if ( typeof query === "string" ) {
+               query = [ query ];
+       }
 
-	for ( i in query ) {
-		if ( Object.prototype.hasOwnProperty.call(query,  i ) ) {
-			data[ query[ i ] ] = localStorage.getItem( query[ i ] );
-		}
-	}
+       for ( i in query ) {
+               if ( Object.prototype.hasOwnProperty.call( query, i ) ) {
+                       data[ query[ i ] ] = OSApp.Storage.getItemSync( query[ i ] );
+               }
+       }
 
-	callback( data );
+       callback( data );
 };
 
 OSApp.Storage.set = function( query, callback ) {
-	callback = callback || function() {};
-	var i;
-	for ( i in query ) {
-		if ( Object.prototype.hasOwnProperty.call(query,  i ) ) {
-			localStorage.setItem( i, query[ i ] );
-		}
-	}
+       callback = callback || function() {};
+       var i;
+       for ( i in query ) {
+               if ( Object.prototype.hasOwnProperty.call( query, i ) ) {
+                       OSApp.Storage.setItemSync( i, query[ i ] );
+               }
+       }
 
-	callback( true );
+       callback( true );
 };
 
 OSApp.Storage.remove = function( query, callback ) {
-	callback = callback || function() {};
-	var i;
+       callback = callback || function() {};
+       var i;
 
-	if ( typeof query === "string" ) {
-		query = [ query ];
-	}
+       if ( typeof query === "string" ) {
+               query = [ query ];
+       }
 
-	for ( i in query ) {
-		if ( Object.prototype.hasOwnProperty.call(query,  i ) ) {
-			localStorage.removeItem( query[ i ] );
-		}
-	}
+       for ( i in query ) {
+               if ( Object.prototype.hasOwnProperty.call( query, i ) ) {
+                       OSApp.Storage.removeItemSync( query[ i ] );
+               }
+       }
 
-	callback( true );
+       callback( true );
 };
 
 OSApp.Storage.loadLocalSettings = function() {

--- a/www/js/modules/weather.js
+++ b/www/js/modules/weather.js
@@ -641,17 +641,20 @@ OSApp.Weather.updateWeather = function() {
 	if ( OSApp.currentSession.weather && OSApp.currentSession.weather.providedLocation === OSApp.currentSession.controller.settings.loc && now - OSApp.currentSession.weather.lastUpdated < 60 * 60 * 100 ) {
 		OSApp.Weather.finishWeatherUpdate();
 		return;
-	} else if ( localStorage.weatherData ) {
-		try {
-			var weatherData = JSON.parse( localStorage.weatherData );
-			if ( weatherData.providedLocation === OSApp.currentSession.controller.settings.loc && now - weatherData.lastUpdated < 60 * 60 * 100 ) {
-				OSApp.currentSession.weather = weatherData;
-				OSApp.Weather.finishWeatherUpdate();
-				return;
-			}
-			//eslint-disable-next-line
-		} catch ( err ) {}
-	}
+       } else {
+               var storedData = OSApp.Storage.getItemSync( "weatherData" );
+               if ( storedData ) {
+                       try {
+                               var weatherData = JSON.parse( storedData );
+                               if ( weatherData.providedLocation === OSApp.currentSession.controller.settings.loc && now - weatherData.lastUpdated < 60 * 60 * 100 ) {
+                                       OSApp.currentSession.weather = weatherData;
+                                       OSApp.Weather.finishWeatherUpdate();
+                                       return;
+                               }
+                               //eslint-disable-next-line
+                       } catch ( err ) {}
+               }
+       }
 
 	OSApp.currentSession.weather = undefined;
 
@@ -694,11 +697,11 @@ OSApp.Weather.updateWeather = function() {
 
 			OSApp.currentSession.weather = data;
 			data.lastUpdated = new Date().getTime();
-			data.providedLocation = OSApp.currentSession.controller.settings.loc;
-			localStorage.weatherData = JSON.stringify( data );
-			OSApp.Weather.finishWeatherUpdate();
-		}
-	} );
+                       data.providedLocation = OSApp.currentSession.controller.settings.loc;
+                       OSApp.Storage.setItemSync( "weatherData", JSON.stringify( data ) );
+                       OSApp.Weather.finishWeatherUpdate();
+               }
+       } );
 };
 
 OSApp.Weather.checkURLandUpdateWeather = function() {


### PR DESCRIPTION
## Summary
- namespace localStorage keys by path to prevent collisions when hosted via reverse proxy
- access new storage helpers in options, weather, and home modules

## Testing
- `npx grunt`
- `npm test` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_683e28dd0934832cab6c5cb1ac492a1c