### PR TITLE
allow user installed CAs

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -87,8 +87,10 @@
     </platform>
     <platform name="android">
         <edit-config file="AndroidManifest.xml" mode="merge" target="/manifest/application">
-            <application android:usesCleartextTraffic="true" />
+            <application android:usesCleartextTraffic="true"
+                android:networkSecurityConfig="@xml/network_security_config" />
         </edit-config>
+        <resource-file src="res/android/network_security_config.xml" target="app/src/main/res/xml/network_security_config.xml" />
         <config-file target="AndroidManifest.xml" parent="queries">
             <intent>
                 <action android:name="android.media.action.IMAGE_CAPTURE" />

--- a/res/android/network_security_config.xml
+++ b/res/android/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+<base-config cleartextTrafficPermitted="true">
+    <trust-anchors>
+        <certificates src="system" />
+        <certificates src="user" />
+    </trust-anchors>
+</base-config>
+</network-security-config>


### PR DESCRIPTION
#### Changes Proposed

I'm using a custom CA to issue SSL certificates for my home services, including OpenSprinkler-PI.
On Android, user installed CA certificates are not picked up by Apps per defaut:
https://developer.android.com/privacy-and-security/security-config
and
https://developer.android.com/privacy-and-security/security-config#base-config

This change adds a network-security-config to the Android App, that allows SSL connections to services which use a certificate that was issued by a user installed CA
