### PR TITLE
Fix "browser-based" basic auth with Firefox

### DIFF
--- a/www/js/modules/ui-dom.js
+++ b/www/js/modules/ui-dom.js
@@ -404,16 +404,6 @@ OSApp.UIDom.initAppData = function() {
 				//eslint-disable-next-line
 			} catch ( err ) {}
 		} );
-	} else if ( OSApp.currentDevice.isFireFox ) {
-
-		// Allow cross domain AJAX requests in FireFox OS
-		$.ajaxSetup( {
-			xhr: function() {
-				return new window.XMLHttpRequest( {
-					mozSystem: true
-				} );
-			}
-		} );
 	} else {
 		$.ajaxSetup( {
 			"cache": false


### PR DESCRIPTION
"Browser-based" auth means skipping the **Add Device** workflow and accessing the OpenSprinkler device's root path (`/`).  In this scenario, the authentication credentials are never entered into the web application, so the web application cannot explicitly set them on its `XMLHttpRequests`.  Instead, the browser prompts for the authentication credentials when it receives a **401** response to the initial root path request.  The browser is then expected to add the credentials (`Authorization` header) to subsequent requests (API calls) to the same realm.

This works today in Google Chrome (both desktop and mobile), but Firefox (desktop and mobile) is not adding the `Authorization` header. This is happening because the web application is setting `mozSystem: true` on its `XMLHttpRequests` when it detects that it is running on Firefox.

Documentation of this property is very limited[1][2][3].  It's purpose is to disable the same origin policy and allow cross-origin resource sharing.  It was added to the web application back in 2014[4], possibly as a workaround for limitations in Firefox's CORS support at the time (although ChatGPT says that Firefox got CORS support in 2009).

Even less well documented is the fact that setting `mozSystem` implies also setting `mozAnon`[5].  In fact, the only documentation that I (or ChatGPT) can find[6] states that `mozSystem` **requires** `mozAnon`. However, testing shows that setting `mozSystem` definitely prevents Firefox from adding the `Authorization` header to `XMLHttpRequests`, which is exactly what `mozAnon` does.

Removing the code that sets `mozSystem: true` (and treating Firefox like any other browser) enables Firefox to correctly add the `Authorization` header to the `XMLHttpRequests` made by the web application, which makes Firefox work with "browser-based" basic authentication.

Furthermore, the change does not have any effect on other configurations - no TLS, no authentication, cross-origin vs. same origin, browser-based vs. app-based authentication, etc.  (I tested more than 60 different combinations of browsers and configurations with a modified copy of the 2.4.1 web application.)  AFAICT, setting `mozSystem: true` doesn't have any benefit on recent versions of Firefox.

This PR fixes issue #273[7].

[1] https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/XMLHttpRequest#mozsystem
[2] https://mdn2.netlify.app/en-us/docs/web/api/xmlhttprequest/mozsystem/
[3] https://bugzilla.mozilla.org/show_bug.cgi?id=692677
[4] https://github.com/OpenSprinkler/OpenSprinkler-App/commit/09d406640
[5] https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/XMLHttpRequest#mozanon
[6] https://udn.realityripple.com/docs/Web/API/XMLHttpRequest/XMLHttpRequest
[7] https://github.com/OpenSprinkler/OpenSprinkler-App/issues/273

#### Changes Proposed

- Remove code that sets `mozSystem: true` property on `XMLHttpRequests` when running on Firefox.

#### Demo Video or Screenshots

I have uploaded a video showing the pre- and post-fix behavior [here](https://drive.google.com/file/d/19qKv9N6YDqeaWRoUjxfCIHY688GwkPp_/view?usp=drive_link).  (It's too large to be directly attached to this PR.)