### PR TITLE
Support/os34dc

### DIFF
--- a/www/css/main.css
+++ b/www/css/main.css
@@ -1150,5 +1150,23 @@ button[id^="start_1-"] {
 	margin-right: 5px;
 }
 
+/*
+  Fix for vertical alignment on desktop/wide screens.
+*/
+@media screen and (min-width: 480px) {
+    /* 1. Turn the container into a flexbox */
+    .ui-field-contain {
+        display: flex;
+        align-items: center;
+    }
 
+    /* 2. Remove the old float property that interferes */
+    .ui-field-contain > label {
+        float: none !important;
+    }
 
+    /* 3. ADDED: Force the sensor fieldset to take full width */
+    .ui-field-contain .sensor-options {
+        width: 100%;
+    }
+}

--- a/www/js/home.js
+++ b/www/js/home.js
@@ -157,10 +157,10 @@ window.currLocal = true;
 						if ( loadedScripts === totalScripts ) {
 							// Once all scripts loaded, insert main.js
 							insertScript( assetLocation + "js/main.js", function () {
-                                                                try {
-                                                                        OSApp.Storage.setItemSync( "testQuota", "true" );
-                                                                        OSApp.Storage.removeItemSync( "testQuota" );
-                                                                        init();
+								try {
+									OSApp.Storage.setItemSync( "testQuota", "true" );
+									OSApp.Storage.removeItemSync( "testQuota" );
+									init();
 								} catch ( err ) {
 									if ( err.code === 22 ) {
 										document.body.innerHTML = "<div class='spinner'><div class='logo'></div>" +
@@ -243,8 +243,8 @@ window.currLocal = true;
 				document.title = "Loading...";
 
 				// Inject site information to storage so Application loads current device
-                                OSApp.Storage.setItemSync( "sites", JSON.stringify( sites ) );
-                                OSApp.Storage.setItemSync( "current_site", currentSite );
+				OSApp.Storage.setItemSync( "sites", JSON.stringify( sites ) );
+				OSApp.Storage.setItemSync( "current_site", currentSite );
 				finishInit();
 			},
 			wrongPassword = function() {
@@ -262,7 +262,7 @@ window.currLocal = true;
 						"<div class='logo'></div><span class='feedback'>Unable to load UI</span>" +
 					"</div>" );
 			},
-                        sites = JSON.parse( OSApp.Storage.getItemSync( "sites" ) ),
+			sites = JSON.parse( OSApp.Storage.getItemSync( "sites" ) ),
 			loader;
 
 		// Fix to allow CORS ajax requests to work on IE8 and 9

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -35,8 +35,8 @@ OSApp.Constants = {
 		"wl":23, "den":24, "ipas":25, "devid":26, "con":27, "lit":28, "dim":29, "bst":30, "uwt":31, "ntp1":32, "ntp2":33,
 		"ntp3":34, "ntp4":35, "lg":36, "mas2":37, "mton2":38, "mtof2":39, "fpr0":41, "fpr1":42, "re":43, "dns1": 44,
 		"dns2":45, "dns3":46, "dns4":47, "sar":48, "ife":49, "sn1t":50, "sn1o":51, "sn2t":52, "sn2o":53, "sn1on":54,
-		"sn1of":55, "sn2on":56, "sn2of":57, "subn1":58, "subn2":59, "subn3":60, "subn4":61, "laton":62, "latof":63,
-		"ife2":64, "imin":65, "imax":66
+		"sn1of":55, "sn2on":56, "sn2of":57, "subn1":58, "subn2":59, "subn3":60, "subn4":61, "fwire":62, "laton":63, "latof":64,
+		"ife2":65, "imin":66, "imax":67, "tpdv":68
 	},
 	options: { // Option constants
 		IGNORE_SENSOR_1: 1,

--- a/www/js/modules/dashboard.js
+++ b/www/js/modules/dashboard.js
@@ -1094,7 +1094,7 @@ OSApp.Dashboard.displayPage = function() {
 						maximum: 64800,
 						seconds: sites[ currentSite ].lastRunTime[ sid ] > 0 ? sites[ currentSite ].lastRunTime[ sid ] : 0,
 						helptext: OSApp.Language._( "Enter a duration to manually run " ) + name,
-						showPreemptCheckbox: OSApp.Groups.canPreempt( stationGID ),
+						showPreemptCheckbox: OSApp.Groups.canPreempt( stationGID ) && OSApp.Stations.isSequential( sid ),
 						callback: function( duration, preempt ) {
 							var preParam = preempt ? "&pre=1" : "";
 							OSApp.Firmware.sendToOS( "/cm?sid=" + sid + "&en=1&t=" + duration + preParam + "&pw=", "json" ).done( function() {

--- a/www/js/modules/dashboard.js
+++ b/www/js/modules/dashboard.js
@@ -970,8 +970,14 @@ OSApp.Dashboard.displayPage = function() {
 
 							// Show the remaining time if it's greater than 0
 							line += " <span id=" + ( qPause ? "'pause" : "'countdown-" ) + sid + "' class='nobr'>(" + OSApp.Dates.sec2hms( rem ) + " " + OSApp.Language._( "remaining" ) + ")</span>";
-							if ( OSApp.currentSession.controller.status[ sid ] ) {
+
+							if ( isRunning ) {
 								addTimer( sid, rem );
+							} else {
+								// Station is scheduled/paused but not running - remove timer if it exists
+								if ( OSApp.uiState.timers[ "station-" + sid ] ) {
+									delete OSApp.uiState.timers[ "station-" + sid ];
+								}
 							}
 						}
 						if ( card.find( ".rem" ).length === 0 ) {
@@ -1088,8 +1094,10 @@ OSApp.Dashboard.displayPage = function() {
 						maximum: 64800,
 						seconds: sites[ currentSite ].lastRunTime[ sid ] > 0 ? sites[ currentSite ].lastRunTime[ sid ] : 0,
 						helptext: OSApp.Language._( "Enter a duration to manually run " ) + name,
-						callback: function( duration ) {
-							OSApp.Firmware.sendToOS( "/cm?sid=" + sid + "&en=1&t=" + duration + "&pw=", "json" ).done( function() {
+						showPreemptCheckbox: OSApp.Groups.canPreempt( stationGID ),
+						callback: function( duration, preempt ) {
+							var preParam = preempt ? "&pre=1" : "";
+							OSApp.Firmware.sendToOS( "/cm?sid=" + sid + "&en=1&t=" + duration + preParam + "&pw=", "json" ).done( function() {
 
 								// Update local state until next device refresh occurs
 								OSApp.Stations.setPID( sid, OSApp.Constants.options.MANUAL_STATION_PID );

--- a/www/js/modules/dashboard.js
+++ b/www/js/modules/dashboard.js
@@ -1094,9 +1094,9 @@ OSApp.Dashboard.displayPage = function() {
 						maximum: 64800,
 						seconds: sites[ currentSite ].lastRunTime[ sid ] > 0 ? sites[ currentSite ].lastRunTime[ sid ] : 0,
 						helptext: OSApp.Language._( "Enter a duration to manually run " ) + name,
-						showPreemptCheckbox: OSApp.Groups.canPreempt( stationGID ) && OSApp.Stations.isSequential( sid ),
-						callback: function( duration, preempt ) {
-							var preParam = preempt ? "&pre=1" : "";
+						showQOCheckbox: OSApp.Groups.canPreempt( stationGID ) && OSApp.Stations.isSequential( sid ),
+						callback: function( duration, qo ) {
+							var preParam = qo ? "&qo=1" : "";
 							OSApp.Firmware.sendToOS( "/cm?sid=" + sid + "&en=1&t=" + duration + preParam + "&pw=", "json" ).done( function() {
 
 								// Update local state until next device refresh occurs

--- a/www/js/modules/groups.js
+++ b/www/js/modules/groups.js
@@ -66,6 +66,11 @@ OSApp.Groups.canShift = function( gid ) {
 	return OSApp.Groups.numActiveStations( gid ) > 1;
 };
 
+// If at least 1 station in this group is active
+OSApp.Groups.canPreempt = function( gid ) {
+	return OSApp.Groups.numActiveStations( gid ) > 0;
+};
+
 // Tbh, not sure if this belongs here in groups.js (mellodev)
 OSApp.Groups.calculateTotalRunningTime = function( runTimes ) {
 	var sdt = OSApp.currentSession.controller.options.sdt,

--- a/www/js/modules/groups.js
+++ b/www/js/modules/groups.js
@@ -63,12 +63,12 @@ OSApp.Groups.numActiveStations = function( gid ) {
 
 // If more than 1 stations (includes the one to be turned off) are active
 OSApp.Groups.canShift = function( gid ) {
-	return OSApp.Groups.numActiveStations( gid ) > 1;
+	return OSApp.Firmware.checkOSVersion( 220 ) && OSApp.Groups.numActiveStations( gid ) > 1;
 };
 
 // If at least 1 station in this group is active
 OSApp.Groups.canPreempt = function( gid ) {
-	return OSApp.Groups.numActiveStations( gid ) > 0;
+	return OSApp.Firmware.checkOSVersion( 2214 ) && ( OSApp.Groups.numActiveStations( gid ) > 0 );
 };
 
 // Tbh, not sure if this belongs here in groups.js (mellodev)

--- a/www/js/modules/logs.js
+++ b/www/js/modules/logs.js
@@ -76,9 +76,9 @@ OSApp.Logs.displayPage = function() {
 			}
 
 			$.each( data, function() {
-                                var station = this[ 1 ],
-                                        duration = parseInt( this[ 2 ] ),
-                                        flowRate = ( typeof this[ 4 ] !== "undefined" ) ? OSApp.Utils.flowRateToVolume( parseFloat( this[ 4 ] ) ) : null;
+				var station = this[ 1 ],
+					duration = parseInt( this[ 2 ] ),
+					flowRate = ( typeof this[ 4 ] !== "undefined" ) ? OSApp.Utils.flowRateToVolume( parseFloat( this[ 4 ] ) ) : null;
 
 				// Adjust for negative watering time firmware bug
 				if ( duration < 0 ) {
@@ -114,15 +114,15 @@ OSApp.Logs.displayPage = function() {
 
 				if ( type === "table" ) {
 					switch ( grouping ) {
-                                                case "station":
-                                                        var stationItem = [ utc, OSApp.Dates.dhms2str( OSApp.Dates.sec2dhms( duration ) ), station, new Date( utc.getTime() + ( duration * 1000 ) ), flowRate ];
-                                                        sortedData[ station ].push( stationItem );
-                                                        break;
-                                                case "day":
-                                                        var day = Math.floor( date.getTime() / 1000 / 60 / 60 / 24 ),
-                                                                item = [ utc, OSApp.Dates.dhms2str( OSApp.Dates.sec2dhms( duration ) ), station, new Date( utc.getTime() + ( duration * 1000 ) ), flowRate ];
+						case "station":
+							var stationItem = [ utc, OSApp.Dates.dhms2str( OSApp.Dates.sec2dhms( duration ) ), station, new Date( utc.getTime() + ( duration * 1000 ) ), flowRate ];
+							sortedData[ station ].push( stationItem );
+							break;
+						case "day":
+							var day = Math.floor( date.getTime() / 1000 / 60 / 60 / 24 ),
+								item = [ utc, OSApp.Dates.dhms2str( OSApp.Dates.sec2dhms( duration ) ), station, new Date( utc.getTime() + ( duration * 1000 ) ), flowRate ];
 
-                                                        // Item structure: [startDate, runtime, station, endDate, flowRate]
+							// Item structure: [startDate, runtime, station, endDate, flowRate]
 
 							if ( typeof sortedData[ day ] !== "object" ) {
 								sortedData[ day ] = [ item ];
@@ -349,13 +349,13 @@ OSApp.Logs.displayPage = function() {
 				wlSorted = extraData[ 0 ],
 				flSorted = extraData[ 1 ],
 				stats = extraData[ 2 ],
-                                tableHeader = "<table class=\"table-logs-datatables\"><thead><tr>" +
-                                        "<th data-priority='1'>" + OSApp.Language._( "Station" ) + "</th>" +
-                                        "<th data-priority='2'>" + OSApp.Language._( "Runtime" ) + "</th>" +
-                                        "<th data-priority='3'>" + OSApp.Language._( "Start Time" ) + "</th>" +
-                                        "<th data-priority='4'>" + OSApp.Language._( "End Time" ) + "</th>" +
-                                        "<th data-priority='5'>" + OSApp.Language._( "Flow Rate" ) + "</th>" +
-                                        "</tr></thead><tbody>",
+				tableHeader = "<table class=\"table-logs-datatables\"><thead><tr>" +
+					"<th data-priority='1'>" + OSApp.Language._( "Station" ) + "</th>" +
+					"<th data-priority='2'>" + OSApp.Language._( "Runtime" ) + "</th>" +
+					"<th data-priority='3'>" + OSApp.Language._( "Start Time" ) + "</th>" +
+					"<th data-priority='4'>" + OSApp.Language._( "End Time" ) + "</th>" +
+					"<th data-priority='5'>" + OSApp.Language._( "Flow Rate" ) + "</th>" +
+					"</tr></thead><tbody>",
 				html = showStats( stats ) + "<div data-role='collapsible-set' data-inset='true' data-theme='b' data-collapsed-icon='arrow-d' data-expanded-icon='arrow-u'>",
 				i = 0,
 				group, ct, k;
@@ -419,20 +419,20 @@ OSApp.Logs.displayPage = function() {
 
 					for ( k = 0; k < sortedData[ group ].length; k++ ) {
 						var sid = ( grouping === 'station' ) ? group  : sortedData[group][k][2];
-						var stationName = OSApp.Stations.getName(sid);
+						var stationName = stations[sid];
 						var runTime = sortedData[ group ][ k ][ 1 ];
 						var startTime = formatTime( sortedData[ group ][ k ][ 0 ], grouping ) ;
-                                                var endTime = formatTime( sortedData[ group ][ k ][ 3 ], grouping );
-                                                var fRate = sortedData[ group ][ k ][ 4 ];
-                                                var flowDisplay = ( typeof fRate === "number" ) ? fRate.toFixed( 2 ) + " L/min" : "";
+						var endTime = formatTime( sortedData[ group ][ k ][ 3 ], grouping );
+						var fRate = sortedData[ group ][ k ][ 4 ];
+						var flowDisplay = ( typeof fRate === "number" ) ? fRate.toFixed( 2 ) + " L/min" : "";
 
-                                                groupArray[ i ] += "<tr>" +
-                                                        "<td>" + stationName + "</td>" + // Station name
-                                                        "<td>" + runTime + "</td>" + // Runtime
-                                                        "<td>" + startTime + "</td>" + // Startdate
-                                                        "<td>" + endTime + "</td>" + // Enddate
-                                                        "<td>" + flowDisplay + "</td>" + // Flow rate
-                                                        "</tr>";
+						groupArray[ i ] += "<tr>" +
+							"<td>" + stationName + "</td>" + // Station name
+							"<td>" + runTime + "</td>" + // Runtime
+							"<td>" + startTime + "</td>" + // Startdate
+							"<td>" + endTime + "</td>" + // Enddate
+							"<td>" + flowDisplay + "</td>" + // Flow rate
+							"</tr>";
 					}
 					groupArray[ i ] += "</tbody></table></div>";
 

--- a/www/js/modules/options.js
+++ b/www/js/modules/options.js
@@ -202,7 +202,7 @@ OSApp.Options.showOptions = function( expandItem ) {
 						return true;
 					case "o49":
 						opt.o49 = data & 0xff;
-						opt.o64 = ( data >> 8 ) & 0xff;
+						opt.o65 = ( data >> 8 ) & 0xff;
 						return true;
 					case "o31":
 						if ( parseInt( data ) === 3 && !OSApp.Utils.unescapeJSON( $( "#wto" )[ 0 ].value ).baseETo ) {

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -47,16 +47,16 @@ OSApp.Programs.displayPage = function(programId) {
 	function updateContent() {
 		var list = $( OSApp.Programs.makeAllPrograms() );
 
-                list.find( "[id^=program-]" ).on( {
-                        collapsiblecollapse: function() {
-                                var pid = $( this ).attr( "id" ).split( "-" )[ 1 ];
-                                var select = $( "#d-" + pid );
-                                if ( select.length && select.data( "mobile-selectmenu" ) ) {
-                                        select.selectmenu( "destroy" );
-                                }
-                                $( "#d-" + pid + "-listbox" ).remove();
-                                $( this ).find( ".ui-collapsible-content" ).empty();
-                        },
+		list.find( "[id^=program-]" ).on( {
+			collapsiblecollapse: function() {
+				var pid = $( this ).attr( "id" ).split( "-" )[ 1 ];
+				var select = $( "#d-" + pid );
+				if ( select.length && select.data( "mobile-selectmenu" ) ) {
+					select.selectmenu( "destroy" );
+				}
+				$( "#d-" + pid + "-listbox" ).remove();
+				$( this ).find( ".ui-collapsible-content" ).empty();
+			},
 			collapsiblebeforecollapse: function( e ) {
 				var program = $( this ),
 					changed = program.find( ".hasChanges" );
@@ -416,6 +416,8 @@ OSApp.Programs.displayPageRunOnce = function() {
 
 			// Show repeating start time options
 			list += "<div id='input_stype_repeat-runonce'>";
+			// Show repeating start time options
+			list += "<div id='input_stype_repeat-runonce'>";
 			list += "<div class='ui-grid-a'>";
 			list += "<div class='ui-block-a'><label class='pad_buttons center' for='interval-runonce'>" + OSApp.Language._( "Repeat Every" ) + "</label>" +
 				"<button class='pad_buttons' data-mini='true' name='interval-runonce' id='interval-runonce' " +
@@ -423,6 +425,23 @@ OSApp.Programs.displayPageRunOnce = function() {
 			list += "<div class='ui-block-b'><label class='pad_buttons center' for='repeat-runonce'>" + OSApp.Language._( "Repeat Count" ) + "</label>" +
 				"<button class='pad_buttons' data-mini='true' name='repeat-runonce' id='repeat-runonce' value='0'>0</button></div>";
 			list += "</div></div>";
+			if (OSApp.Firmware.checkOSVersion ( 2214 ) ) {
+				list += "<fieldset data-role='controlgroup' data-mini='true' id='queue-option' style='margin:12px 0 20px 0;'>" +
+						"<legend class='center'><b>" + OSApp.Language._("Scheduling Option") + "</b></legend>" +
+						"<label for='pre-append'>" +
+							"<input type='radio' name='pre-runonce' id='pre-append' value='0'>" +
+							OSApp.Language._("Run After Others (Append)") +
+						"</label>" +
+						"<label for='pre-insert'>" +
+							"<input type='radio' name='pre-runonce' id='pre-insert' value='1'>" +
+							OSApp.Language._("Run Now and Pause Others (Insert to front)") +
+						"</label>" +
+						"<label for='pre-replace'>" +
+							"<input type='radio' name='pre-runonce' id='pre-replace' value='2' checked='checked'>" +
+							OSApp.Language._("Run Now and Cancel Others (Replace)") +
+						"</label>" +
+						"</fieldset>";
+			}
 		}
 
 		list += "<a class='ui-btn ui-corner-all ui-shadow rsubmit' href='#'>" + OSApp.Language._( "Submit" ) + "</a>" +

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -2872,7 +2872,7 @@ OSApp.Programs.expandProgram = function( program ) {
 			e.preventDefault();
 			$("#run-program-dialog").popup("close");
 
-			var uwt = $("#rp-apply-wl").is(":checked");
+			var uwt = $("#rp-apply-wl").is(":checked") ? 1 : 0;
 			if ( !$("#rp-create-single").is(":checked") || !isRepeatProgram ) {
 				interval = 0;
 				repeat = 0;
@@ -2884,7 +2884,7 @@ OSApp.Programs.expandProgram = function( program ) {
 
 			runonce.push(0); // for legacy firmwares, need an extra element at the end
 
-			if ( !OSApp.Supported.repeatedRunonce() ) { // if the /cr endpoint doesn't support uwt flag, we apply uwt manually here
+			if ( uwt && !OSApp.Supported.repeatedRunonce() ) { // if the /cr endpoint doesn't support uwt flag, we apply uwt manually here
 				var wl = OSApp.currentSession.controller.options.wl || 100;  // fallback to 100% if undefined
 				for (var i = 0; i < runonce.length; i++) {
 					runonce[i] = Math.floor(runonce[i] * wl / 100);

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -429,16 +429,16 @@ OSApp.Programs.displayPageRunOnce = function() {
 			if ( OSApp.StationQueue.isActive() !== -1 && OSApp.Firmware.checkOSVersion ( 2214 ) ) {
 				list += "<fieldset data-role='controlgroup' data-mini='true' id='queue-option' style='margin:12px 0 20px 0;'>" +
 						"<legend class='center'><b>" + OSApp.Language._("Scheduling Option") + "</b></legend>" +
-						"<label for='pre-append'>" +
-							"<input type='radio' name='pre-runonce' id='pre-append' value='0'>" +
+						"<label for='qo-append'>" +
+							"<input type='radio' name='qo-runonce' id='qo-append' value='0'>" +
 							OSApp.Language._("Run After Others (Append)") +
 						"</label>" +
-						"<label for='pre-insert'>" +
-							"<input type='radio' name='pre-runonce' id='pre-insert' value='1'>" +
+						"<label for='qo-insert'>" +
+							"<input type='radio' name='qo-runonce' id='qo-insert' value='1'>" +
 							OSApp.Language._("Run Now and Pause Others (Insert to front)") +
 						"</label>" +
-						"<label for='pre-replace'>" +
-							"<input type='radio' name='pre-runonce' id='pre-replace' value='2' checked='checked'>" +
+						"<label for='qo-replace'>" +
+							"<input type='radio' name='qo-runonce' id='qo-replace' value='2' checked='checked'>" +
 							OSApp.Language._("Run Now and Cancel Others (Replace)") +
 						"</label>" +
 						"</fieldset>";
@@ -2763,12 +2763,12 @@ OSApp.Programs.openRunProgramDialog = function (pid, stationsDurations, uwt, isR
 						</label>
 					</fieldset>
 
-					<div id="rp-pre-wrap" style="display:none;margin-top:10px;">
-						<fieldset data-role="controlgroup" data-mini="true" id="rp-pre-group">
+					<div id="rp-qo-wrap" style="display:none;margin-top:10px;">
+						<fieldset data-role="controlgroup" data-mini="true" id="rp-qo-group">
 							<legend class="center"><b>${OSApp.Language._("Scheduling Option")}</b></legend>
-							<label for="rp-pre-append"><input type="radio" name="rp-pre" id="rp-pre-append" value="0">${OSApp.Language._("Run After Others")}</label>
-							<label for="rp-pre-insert"><input type="radio" name="rp-pre" id="rp-pre-insert" value="1">${OSApp.Language._("Run Now and Pause Others")}</label>
-							<label for="rp-pre-replace"><input type="radio" name="rp-pre" id="rp-pre-replace" value="2" checked>${OSApp.Language._("Run Now and Cancel Others")}</label>
+							<label for="rp-qo-append"><input type="radio" name="rp-qo" id="rp-qo-append" value="0">${OSApp.Language._("Run After Others")}</label>
+							<label for="rp-qo-insert"><input type="radio" name="rp-qo" id="rp-qo-insert" value="1">${OSApp.Language._("Run Now and Pause Others")}</label>
+							<label for="rp-qo-replace"><input type="radio" name="rp-qo" id="rp-qo-replace" value="2" checked>${OSApp.Language._("Run Now and Cancel Others")}</label>
 						</fieldset>
 					</div>
 
@@ -2796,9 +2796,9 @@ OSApp.Programs.openRunProgramDialog = function (pid, stationsDurations, uwt, isR
 	$("#rp-repeat-wrap").toggle(!!isRepeatProgram);
 
 	// Show/hide scheduling options
-	var supportsPre = OSApp.Firmware.checkOSVersion(2214);
+	var supportsQO = OSApp.Firmware.checkOSVersion(2214);
 	var hasActive = ( OSApp.StationQueue.isActive() !== -1 );
-	$("#rp-pre-wrap").toggle(supportsPre && hasActive);
+	$("#rp-qo-wrap").toggle(supportsQO && hasActive);
 
 	// Rebind buttons
 	$("#rp-cancel").off("click").on("click", function (e) {
@@ -2878,9 +2878,9 @@ OSApp.Programs.expandProgram = function( program ) {
 				repeat = 0;
 			}
 
-			var supportsPre = OSApp.Firmware.checkOSVersion(2214);
+			var supportsQO = OSApp.Firmware.checkOSVersion(2214);
 			var hasActive = ( OSApp.StationQueue.isActive() !== -1 );
-			var pre = (supportsPre && hasActive) ? ($("input[name='rp-pre']:checked").val() || "2") : "2";
+			var qo = (supportsQO && hasActive) ? ($("input[name='rp-qo']:checked").val() || "2") : "2";
 
 			runonce.push(0); // for legacy firmwares, need an extra element at the end
 
@@ -2890,7 +2890,7 @@ OSApp.Programs.expandProgram = function( program ) {
 					runonce[i] = Math.floor(runonce[i] * wl / 100);
 				}
 			}
-			OSApp.Stations.submitRunonce(runonce, uwt, interval, repeat, annotation, pre);
+			OSApp.Stations.submitRunonce(runonce, uwt, interval, repeat, annotation, qo);
 		} );
 	} );
 };

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -1878,7 +1878,7 @@ OSApp.Programs.makeProgram183 = function( n, isCopy ) {
 		days, i, j, setStations, program, page;
 
 	if ( n === "new" ) {
-		program = { "en":0, "weather":0, "type":0, "is_even":0, "is_odd":0, "duration":0, "interval":0, "start":0, "end":0, "days":[ 0, 0 ] };
+		program = { "en":0, "weather":0, "type":0, "is_even":0, "is_odd":0, "duration":0, "interval":0, "start":0, "end":0, "days":[ 1, 0 ] };
 	} else {
 		program = OSApp.Programs.readProgram( OSApp.currentSession.controller.programs.pd[ n ] );
 	}
@@ -2048,7 +2048,7 @@ OSApp.Programs.makeProgram21 = function( n, isCopy ) {
 		days, i, j, program, page, times, time, unchecked;
 
 	if ( n === "new" ) {
-		program = { "name":"", "en":0, "weather":0, "type":0, "is_even":0, "is_odd":0, "interval":0, "start":0, "days":[ 0, 0 ], "repeat":0, "stations":[] };
+		program = { "name":"", "en":0, "weather":0, "type":0, "is_even":0, "is_odd":0, "interval":0, "start":0, "days":[ 1, 0 ], "repeat":0, "stations":[] };
 	} else {
 		program = OSApp.Programs.readProgram( OSApp.currentSession.controller.programs.pd[ n ] );
 	}

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -2777,7 +2777,7 @@ OSApp.Programs.openRunProgramDialog = function (pid, stationsDurations, uwt, isR
 					<fieldset data-role="controlgroup" data-mini="true">
 						<label>
 							<input type="checkbox" id="rp-apply-wl">
-							${OSApp.Language._("Apply current watering level")}
+							${OSApp.Language._("Apply current watering level")} <span id="rp-apply-wl-percent">
 						</label>
 					</fieldset>
 
@@ -2816,6 +2816,10 @@ OSApp.Programs.openRunProgramDialog = function (pid, stationsDurations, uwt, isR
 
 	// Inherit program setting's uwt flag
 	var apply = !!uwt;
+	var currentWL = OSApp.currentSession.controller.options.wl ?? 100;
+	var percentText = "(" + currentWL + "%)";
+	$popup.find("#rp-apply-wl-percent").text(percentText);
+
 	$("#rp-apply-wl").prop("checked", apply);
 	if ($("#rp-apply-wl").closest(".ui-checkbox").length) {
 		$("#rp-apply-wl").checkboxradio("refresh");
@@ -2935,7 +2939,7 @@ OSApp.Programs.expandProgram = function( program ) {
 			runonce.push(0); // for legacy firmwares, need an extra element at the end
 
 			if ( uwt && !OSApp.Supported.repeatedRunonce() ) { // if the /cr endpoint doesn't support uwt flag, we apply uwt manually here
-				var wl = OSApp.currentSession.controller.options.wl || 100;  // fallback to 100% if undefined
+				var wl = OSApp.currentSession.controller.options.wl ?? 100;  // fallback to 100% if undefined or null
 				for (var i = 0; i < runonce.length; i++) {
 					runonce[i] = Math.floor(runonce[i] * wl / 100);
 				}

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -107,6 +107,7 @@ OSApp.Programs.displayPage = function(programId) {
 		} );
 
 		page.find( "#programs_list" ).html( list.enhanceWithin() );
+		OSApp.Programs.updateProgramHeader();
 	}
 
 	function begin() {

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -425,7 +425,8 @@ OSApp.Programs.displayPageRunOnce = function() {
 			list += "<div class='ui-block-b'><label class='pad_buttons center' for='repeat-runonce'>" + OSApp.Language._( "Repeat Count" ) + "</label>" +
 				"<button class='pad_buttons' data-mini='true' name='repeat-runonce' id='repeat-runonce' value='0'>0</button></div>";
 			list += "</div></div>";
-			if (OSApp.Firmware.checkOSVersion ( 2214 ) ) {
+
+			if ( OSApp.StationQueue.isActive() !== -1 && OSApp.Firmware.checkOSVersion ( 2214 ) ) {
 				list += "<fieldset data-role='controlgroup' data-mini='true' id='queue-option' style='margin:12px 0 20px 0;'>" +
 						"<legend class='center'><b>" + OSApp.Language._("Scheduling Option") + "</b></legend>" +
 						"<label for='pre-append'>" +

--- a/www/js/modules/programs.js
+++ b/www/js/modules/programs.js
@@ -2739,10 +2739,6 @@ OSApp.Programs.submitProgram21 = function( id, ignoreWarning ) {
 };
 
 OSApp.Programs.openRunProgramDialog = function (pid, stationsDurations, uwt, isRepeatProgram) {
-	var $page =
-		($.mobile.pageContainer && $.mobile.pageContainer.pagecontainer("getActivePage")) ||
-		$(".ui-page-active") || $(document.body);
-
 	var $popup = $("#run-program-dialog");
 
 	if (!$popup.length) {

--- a/www/js/modules/station-attributes.js
+++ b/www/js/modules/station-attributes.js
@@ -91,7 +91,7 @@ OSApp.StationAttributes.getDisabled = function( sid ) {
 
 OSApp.StationAttributes.getSequential = function( sid ) {
 	if ( OSApp.Supported.groups() ) {
-		return OSApp.Stations.getGIDValue !== OSApp.Constants.options.PARALLEL_GID_VALUE ? 1 : 0;
+		return OSApp.Stations.getGIDValue( sid ) !== OSApp.Constants.options.PARALLEL_GID_VALUE ? 1 : 0;
 	}
 	if ( !OSApp.Supported.sequential() ) { return 0; }
 	var bid = ( sid / 8 ) >> 0,

--- a/www/js/modules/station-queue.js
+++ b/www/js/modules/station-queue.js
@@ -17,7 +17,7 @@ OSApp.StationQueue = OSApp.StationQueue || {};
 
 OSApp.StationQueue.isActive = function() {
 	for ( var i = 0; i < OSApp.currentSession.controller.status.length; i++ ) {
-		if ( OSApp.Stations.getStatus( i ) > 0 && OSApp.Stations.getPID( i ) > 0 ) {
+		if ( OSApp.Stations.getPID( i ) > 0 ) {
 			return i;
 		}
 	}

--- a/www/js/modules/stations.js
+++ b/www/js/modules/stations.js
@@ -253,20 +253,20 @@ OSApp.Stations.submitRunonce = function( runonce, uwt, interval, repeat, annotat
 
 		if( OSApp.Supported.repeatedRunonce() ){
 			// Set up all parameters if needed
-			if( !(typeof uwt === "number") ) {
+			if( uwt == null ) {
 				uwt = $( "#runonce" ).find( "#uwt-runonce" ).prop( "checked" ) ? 1 : 0;
 			}
 
-			if( !(typeof interval === "number" ) ) {
+			if( interval == null ) {
 				interval = $( "#runonce" ).find( "#interval-runonce").val() / 60;
 			}
-			if( !(typeof repeat === "number" ) ) {
+			if( repeat == null ) {
 				repeat = $( "#runonce" ).find( "#repeat-runonce").val();
 			}
 		}
 
 		if ( OSApp.Firmware.checkOSVersion ( 2214 ) ) {
-			if ( !(typeof pre === "number" ) ) {
+			if ( pre == null ) {
 				pre = $("input[name='pre-runonce']:checked").val();
 			}
 		}
@@ -285,7 +285,7 @@ OSApp.Stations.submitRunonce = function( runonce, uwt, interval, repeat, annotat
 			}
 		}
 		if ( OSApp.Firmware.checkOSVersion ( 2214 ) ) {
-			if ( typeof pre === "number" ) {
+			if ( pre != null ) {
 				request += "&pre=" + pre;
 			}
 		}

--- a/www/js/modules/stations.js
+++ b/www/js/modules/stations.js
@@ -302,11 +302,14 @@ OSApp.Stations.submitRunonce = function( runonce, uwt, interval, repeat, annotat
 	isOn = OSApp.StationQueue.isActive();
 
 	var checkIsOnAndSubmit = function() {
-		if ( !OSApp.Firmware.checkOSVersion ( 2214 ) && isOn !== -1){
-			OSApp.UIDom.areYouSure( OSApp.Language._( "Do you want to stop the currently running program?" ), OSApp.Programs.pidToName( OSApp.Stations.getPID( isOn ) ), function() {
-				$.mobile.loading( "show" );
-				OSApp.Stations.stopStations( submit );
-			} );
+		if ( !OSApp.Firmware.checkOSVersion ( 2214 ) && isOn !== -1 ){
+			// Add a short delay to allow the first popup to finish closing
+			setTimeout(function() {
+				OSApp.UIDom.areYouSure( OSApp.Language._( "Do you want to stop the currently running program?" ), OSApp.Programs.pidToName( OSApp.Stations.getPID( isOn ) ), function() {
+					$.mobile.loading( "show" );
+					OSApp.Stations.stopStations( submit );
+				} );
+			}, 100); // 100ms delay is usually enough for the DOM to settle
 		} else {
 			submit();
 		}

--- a/www/js/modules/stations.js
+++ b/www/js/modules/stations.js
@@ -241,7 +241,7 @@ OSApp.Stations.convertRemoteToExtender = function( data ) {
 	} );
 };
 
-OSApp.Stations.submitRunonce = function( runonce, uwt, interval, repeat, annotation, pre ) {
+OSApp.Stations.submitRunonce = function( runonce, uwt, interval, repeat, annotation, qo ) {
 	// This block is for the Run-Once Page *only*.
 	// It detects if `runonce` is not an array, meaning it's being called from the page.
 	if ( !( runonce instanceof Array ) ) {
@@ -266,8 +266,8 @@ OSApp.Stations.submitRunonce = function( runonce, uwt, interval, repeat, annotat
 		}
 
 		if ( OSApp.Firmware.checkOSVersion ( 2214 ) ) {
-			if ( pre == null ) {
-				pre = $("input[name='pre-runonce']:checked").val();
+			if ( qo == null ) {
+				qo = $("input[name='qo-runonce']:checked").val();
 			}
 		}
 	}
@@ -285,8 +285,8 @@ OSApp.Stations.submitRunonce = function( runonce, uwt, interval, repeat, annotat
 			}
 		}
 		if ( OSApp.Firmware.checkOSVersion ( 2214 ) ) {
-			if ( pre != null ) {
-				request += "&pre=" + pre;
+			if ( qo != null ) {
+				request += "&qo=" + qo;
 			}
 		}
 

--- a/www/js/modules/stations.js
+++ b/www/js/modules/stations.js
@@ -266,13 +266,21 @@ OSApp.Stations.submitRunonce = function( runonce, interval, repeat, annotation )
 	var submit = function() {
 		$.mobile.loading( "show" );
 		OSApp.Storage.set( { "runonce": JSON.stringify( runonce ) } );
+
 		let request = "/cr?pw=&t=" + JSON.stringify( runonce );
+
 		if ( OSApp.Supported.repeatedRunonce() ) {
 			request += "&int=" + interval + "&cnt=" + repeat + "&uwt=" + weather;
 			if ( annotation?.length > 0 ) {
 				request += "&anno=" + annotation;
 			}
 		}
+		if ( OSApp.Firmware.checkOSVersion ( 2214 ) ) {
+			var preVal = $("input[name='pre-runonce']:checked").val();
+			if (preVal === undefined || preVal === null || preVal === "") { preVal = "2"; }
+			request += "&pre=" + preVal;
+		}
+
 		OSApp.Firmware.sendToOS( request ).done( function() {
 			$.mobile.loading( "hide" );
 			$.mobile.document.one( "pageshow", function() {
@@ -285,7 +293,7 @@ OSApp.Stations.submitRunonce = function( runonce, interval, repeat, annotation )
 	isOn = OSApp.StationQueue.isActive();
 
 	var checkIsOnAndSubmit = function() {
-		if ( isOn !== -1){
+		if ( !OSApp.Firmware.checkOSVersion ( 2214 ) && isOn !== -1){
 			OSApp.UIDom.areYouSure( OSApp.Language._( "Do you want to stop the currently running program?" ), OSApp.Programs.pidToName( OSApp.Stations.getPID( isOn ) ), function() {
 				$.mobile.loading( "show" );
 				OSApp.Stations.stopStations( submit );

--- a/www/js/modules/status.js
+++ b/www/js/modules/status.js
@@ -198,16 +198,37 @@ OSApp.Status.checkStatus = function() {
 				var infoText = OSApp.Language._(
 					"The controller detected one or more zones drawing too much current, exceeding the limit. " +
 					"Please check your wiring and perform a <b>solenoid resistance test</b>. " +
-					"After fixing, reboot the controller to clear the fault message. " +
+					"After fixing, you can clear the alert here. " +
 					"For more instructions, visit our support site"
 				) + ": <a href='https://support.opensprinkler.com' target='_blank' rel='noopener'>support.opensprinkler.com</a>.";
+
 				var popup = $(
 					"<div data-role='popup' data-theme='a' class='ocs-popup' id='ocsInfo'>" +
 						"<div class='ui-content ocs-popup-content'>" +
 							"<p class='ocs-text'>" + infoText + "</p>" +
+							"<a href='#' id='ocsClearBtn' class='ui-btn ui-btn-b ui-corner-all ui-shadow'>" +
+								OSApp.Language._('Clear this alert') +
+							"</a>" +
 						"</div>" +
 					"</div>"
 				);
+
+				popup.find( "#ocsClearBtn" ).on( "click", function( e ) {
+					e.preventDefault(); // Prevent link navigation
+					// Show loading indicator inside the popup
+					OSApp.UIDom.showLoading( popup.find( ".ui-content" ) );
+					// Send the command to clear the OCS alert
+					OSApp.Firmware.sendToOS( "/cv?pw=&rocs=1" ).done( function() { // Added pw= for compatibility
+						// On success, close the popup and refresh the status
+						popup.popup( "close" );
+						OSApp.Status.refreshStatus();
+					} ).fail( function() {
+						// On failure, just close the popup and let the user try again
+						popup.popup( "close" );
+						OSApp.Network.networkFail(); // Show a network fail error
+					} );
+				} );
+
 				// Open the popup dialog
 				OSApp.UIDom.openPopup( popup );
 			}

--- a/www/js/modules/ui-dom.js
+++ b/www/js/modules/ui-dom.js
@@ -1486,7 +1486,7 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 			showSun: false,
 			minimum: 0,
 			showPreemptCheckbox: false,
-			preemptLabel: OSApp.Language._( "Run now (preempt zones in this group)" ),
+			preemptLabel: OSApp.Language._( "Run immediately (preempt other zones in this group)" ),
 			callback: function() {}
 		},
 		type = 0;
@@ -1552,7 +1552,7 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 					"</div>" +
 				"</div>" : "" ) +
 				( opt.showPreemptCheckbox ? "<label for='preempt-checkbox' class='center'>" +
-					"<input type='checkbox' id='preempt-checkbox' data-mini='true' checked='checked'>" +
+					"<input type='checkbox' id='preempt-checkbox' checked='checked'>" +
 					opt.preemptLabel +
 				"</label>" : "" ) +
 				( opt.showBack ? "<button class='submit' data-theme='b'>" + OSApp.Language._( "Submit" ) + "</button>" : "" ) +

--- a/www/js/modules/ui-dom.js
+++ b/www/js/modules/ui-dom.js
@@ -302,7 +302,7 @@ OSApp.UIDom.showHomeMenu = ( function() {
 				"<li><a href='#raindelay'>" + OSApp.Language._( "Change Rain Delay" ) + "</a></li>" +
 				( OSApp.Supported.pausing() ?
 					( OSApp.StationQueue.isPaused() ? "<li><a href='#globalpause'>" + OSApp.Language._( "Change Pause" ) + "</a></li>"
-						: ( OSApp.StationQueue.isActive() >= -1 ? "<li><a href='#globalpause'>" + OSApp.Language._( "Pause Station Runs" ) + "</a></li>" : "" ) )
+						: ( "<li><a href='#globalpause'>" + OSApp.Language._( "Pause Station Runs" ) + "</a></li>" ) )
 					: "" ) +
 				"<li><a href='#runonce'>" + OSApp.Language._( "Run-Once Program" ) + "</a></li>" +
 				"<li><a href='#programs'>" + OSApp.Language._( "Edit Programs" ) + "</a></li>" +

--- a/www/js/modules/ui-dom.js
+++ b/www/js/modules/ui-dom.js
@@ -244,7 +244,7 @@ OSApp.UIDom.launchApp = function() {
 		if ( OSApp.currentSession.isControllerConnected() && newpage !== "#site-control" && newpage !== "#start" && newpage !== "#loadingPage" ) {
 
 			// Update the controller status every 5 seconds and the program and station data every 30 seconds
-			var refreshStatusInterval = setInterval( function() { OSApp.Status.refreshStatus(); }, 5000 ), // FIXME: refactor this 5000 interval out to Constants or config/settings
+			var refreshStatusInterval = setInterval( function() { OSApp.Status.refreshStatus(); }, 4000 ), // FIXME: refactor this 4000 interval out to Constants or config/settings
 				refreshDataInterval;
 
 			if ( !OSApp.Firmware.checkOSVersion( 216 ) ) {
@@ -1485,6 +1485,8 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 			showBack: true,
 			showSun: false,
 			minimum: 0,
+			showPreemptCheckbox: false,
+			preemptLabel: OSApp.Language._( "Run now (preempt zones in this group)" ),
 			callback: function() {}
 		},
 		type = 0;
@@ -1549,6 +1551,10 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 						"<button value='65535' class='ui-mini ui-btn set " + ( type === 1 ? "ui-btn-active" : "" ) + "'>" + OSApp.Language._( "Sunset to Sunrise" ) + "</button>" +
 					"</div>" +
 				"</div>" : "" ) +
+				( opt.showPreemptCheckbox ? "<label for='preempt-checkbox' class='center'>" +
+					"<input type='checkbox' id='preempt-checkbox' data-mini='true' checked='checked'>" +
+					opt.preemptLabel +
+				"</label>" : "" ) +
 				( opt.showBack ? "<button class='submit' data-theme='b'>" + OSApp.Language._( "Submit" ) + "</button>" : "" ) +
 			"</div>" +
 		"</div>" ),
@@ -1574,7 +1580,7 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 
 			input.val( val + dir );
 			if ( opt.incrementalUpdate ) {
-				opt.callback( getValue() );
+				opt.callback( getValue(), getPreempt() );
 			}
 
 			if ( !opt.preventCompression && OSApp.Firmware.checkOSVersion( 210 ) ) {
@@ -1614,6 +1620,12 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 				} );
 			}
 		},
+		getPreempt = function() {
+			if ( opt.showPreemptCheckbox ) {
+				return popup.find( "#preempt-checkbox" ).is( ":checked" );
+			}
+			return false;
+		},
 		toggleInput = function( field, state ) {
 			popup.find( "." + field ).toggleClass( "ui-state-disabled", state ).prop( "disabled", state ).val( function() {
 				if ( state ) {
@@ -1641,7 +1653,7 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 	popup.find( "span" ).prepend( incrbts + inputs + decrbts );
 
 	popup.find( "button.submit" ).on( "click", function() {
-		opt.callback( getValue() );
+		opt.callback( getValue(), getPreempt() );
 		popup.popup( "destroy" ).remove();
 	} );
 
@@ -1699,7 +1711,7 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 			}
 
 			if ( opt.incrementalUpdate ) {
-				opt.callback( getValue() );
+				opt.callback( getValue(), getPreempt() );
 			}
 		} );
 	}
@@ -1713,7 +1725,7 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 	} )
 	.one( "popupafterclose", function() {
 		if ( opt.incrementalUpdate ) {
-			opt.callback( getValue() );
+			opt.callback( getValue(), getPreempt() );
 		}
 	} );
 

--- a/www/js/modules/ui-dom.js
+++ b/www/js/modules/ui-dom.js
@@ -1485,8 +1485,8 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 			showBack: true,
 			showSun: false,
 			minimum: 0,
-			showPreemptCheckbox: false,
-			preemptLabel: OSApp.Language._( "Run immediately (preempt other zones in this group)" ),
+			showQOCheckbox: false,
+			qoLabel: OSApp.Language._( "Run immediately (preempt other zones in this group)" ),
 			callback: function() {}
 		},
 		type = 0;
@@ -1551,9 +1551,9 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 						"<button value='65535' class='ui-mini ui-btn set " + ( type === 1 ? "ui-btn-active" : "" ) + "'>" + OSApp.Language._( "Sunset to Sunrise" ) + "</button>" +
 					"</div>" +
 				"</div>" : "" ) +
-				( opt.showPreemptCheckbox ? "<label for='preempt-checkbox' class='center'>" +
-					"<input type='checkbox' id='preempt-checkbox' checked='checked'>" +
-					opt.preemptLabel +
+				( opt.showQOCheckbox ? "<label for='qo-checkbox' class='center'>" +
+					"<input type='checkbox' id='qo-checkbox' checked='checked'>" +
+					opt.qoLabel +
 				"</label>" : "" ) +
 				( opt.showBack ? "<button class='submit' data-theme='b'>" + OSApp.Language._( "Submit" ) + "</button>" : "" ) +
 			"</div>" +
@@ -1580,7 +1580,7 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 
 			input.val( val + dir );
 			if ( opt.incrementalUpdate ) {
-				opt.callback( getValue(), getPreempt() );
+				opt.callback( getValue(), getQueueOption() );
 			}
 
 			if ( !opt.preventCompression && OSApp.Firmware.checkOSVersion( 210 ) ) {
@@ -1620,9 +1620,9 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 				} );
 			}
 		},
-		getPreempt = function() {
-			if ( opt.showPreemptCheckbox ) {
-				return popup.find( "#preempt-checkbox" ).is( ":checked" );
+		getQueueOption = function() {
+			if ( opt.showQOCheckbox ) {
+				return popup.find( "#qo-checkbox" ).is( ":checked" );
 			}
 			return false;
 		},
@@ -1653,7 +1653,7 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 	popup.find( "span" ).prepend( incrbts + inputs + decrbts );
 
 	popup.find( "button.submit" ).on( "click", function() {
-		opt.callback( getValue(), getPreempt() );
+		opt.callback( getValue(), getQueueOption() );
 		popup.popup( "destroy" ).remove();
 	} );
 
@@ -1711,7 +1711,7 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 			}
 
 			if ( opt.incrementalUpdate ) {
-				opt.callback( getValue(), getPreempt() );
+				opt.callback( getValue(), getQueueOption() );
 			}
 		} );
 	}
@@ -1725,7 +1725,7 @@ OSApp.UIDom.showDurationBox = function( opt ) {
 	} )
 	.one( "popupafterclose", function() {
 		if ( opt.incrementalUpdate ) {
-			opt.callback( getValue(), getPreempt() );
+			opt.callback( getValue(), getQueueOption() );
 		}
 	} );
 

--- a/www/js/modules/weather.js
+++ b/www/js/modules/weather.js
@@ -704,11 +704,20 @@ OSApp.Weather.updateWeather = function() {
 OSApp.Weather.checkURLandUpdateWeather = function() {
 	var finish = function( wsp ) {
 		if ( wsp ) {
-			OSApp.currentSession.weatherServerUrl = OSApp.currentSession.prefix + wsp;
+			if ( OSApp.Firmware.checkOSVersion( 2213 ) ) {
+				if ( /^https?:\/\//i.test(wsp) ) { // If a scheme is already present, honor it.
+					OSApp.currentSession.weatherServerUrl = wsp.replace(/\/+$/, "");
+				} else { // Default to HTTPS for custom WSP.to be consistent with firmware
+					OSApp.currentSession.weatherServerUrl = ("https://" + wsp).replace(/\/+$/, "");
+				}
+			} else {
+				OSApp.currentSession.weatherServerUrl = OSApp.currentSession.prefix + wsp;
+			}
 		} else {
 			OSApp.currentSession.weatherServerUrl = OSApp.Constants.weather.DEFAULT_WEATHER_SERVER_URL;
 		}
-
+		console.log(wsp);
+		console.log(OSApp.currentSession.weatherServerUrl);
 		OSApp.Weather.updateWeather();
 	};
 

--- a/www/js/modules/weather.js
+++ b/www/js/modules/weather.js
@@ -704,7 +704,7 @@ OSApp.Weather.updateWeather = function() {
 OSApp.Weather.checkURLandUpdateWeather = function() {
 	var finish = function( wsp ) {
 		if ( wsp ) {
-			if ( OSApp.Firmware.checkOSVersion( 2213 ) ) {
+			if ( OSApp.Firmware.checkOSVersion( 2214 ) ) {
 				if ( /^https?:\/\//i.test(wsp) ) { // If a scheme is already present, honor it.
 					OSApp.currentSession.weatherServerUrl = wsp.replace(/\/+$/, "");
 				} else { // Default to HTTPS for custom WSP.to be consistent with firmware
@@ -716,8 +716,6 @@ OSApp.Weather.checkURLandUpdateWeather = function() {
 		} else {
 			OSApp.currentSession.weatherServerUrl = OSApp.Constants.weather.DEFAULT_WEATHER_SERVER_URL;
 		}
-		console.log(wsp);
-		console.log(OSApp.currentSession.weatherServerUrl);
 		OSApp.Weather.updateWeather();
 	};
 


### PR DESCRIPTION
close #281
close #279  
- Support for OS 3.4 DC (setting target PD voltage and displaying actual PD voltage)
- Support queuing option for manual actions (`qo` parameter in `/cm, /cr, /mp`). Works on firmware 2.2.1(4) or above.
- Refactor and simplify `submitRunOnce` function, including converting the previous multi-modal confirmations to a single dialog.
- Add `Clear this alert` to overcurrent alert in status bar
- Supports http/https scheme in user-defined `wsp` (issue #279)
- Fixed a few bugs:
    - After a zone is postponed, its count down timer was still running
    - Rain delay (and sensors) events were displayed incorrectly in log
    - `OSApp.StationAttributes.getSequential` was calling `getGIDValue` without a parameter
    - Deleting a program alters (until page refresh) the disabled status of programs behind it
    - `OSApp.StationQueue.isActive` was only counting running stations (not including paused)
    - keyIndex mismatch (issue #281)
