### PR TITLE
Fix backup restore and mutation failures

### DIFF
--- a/.github/workflows/app-store-connect.yml
+++ b/.github/workflows/app-store-connect.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build_ios:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
         with:

--- a/test/tests/import_export_checks.js
+++ b/test/tests/import_export_checks.js
@@ -251,7 +251,8 @@ describe("Import/Export Checks", function () {
 			backup.programs.pd = [
 				program("Morning & East=West", { flag: 1, uuid: 42, splits: [ { x: 0, y: 50 } ] }),
 				program("Disabled adjustment", { flag: 0, uuid: 42, splits: [ { x: 10, y: 0.75 } ] }),
-				program("Empty adjustment", {})
+				program("Empty adjustment", {}),
+				program("Disabled without points", { flag: 4, uuid: 42, splits: [] })
 			];
 
 			return cleanupAfter(asNative(OSApp.ImportExport.importConfig(backup)).then(function () {
@@ -273,6 +274,8 @@ describe("Import/Export Checks", function () {
 				assert.include(programCommands[1], "&snadj=0,42,10,0.75");
 				assert.include(programCommands[2], "&name=Empty%20adjustment");
 				assert.include(programCommands[2], "&snadj=0,0");
+				assert.include(programCommands[3], "&name=Disabled%20without%20points");
+				assert.include(programCommands[3], "&snadj=4,42");
 				assert.notInclude(commands.join("\n"), "/csn?");
 				assert.notInclude(commands.join("\n"), "/dsn?");
 				assert.notInclude(commands.join("\n"), "/jsn?");
@@ -774,8 +777,13 @@ describe("Import/Export Checks", function () {
 			malformedNonEmptyAdjustment.programs.pd = [ program("Incomplete adjustment", { uuid: 1 }) ];
 			OSApp.ImportExport.importConfig(malformedNonEmptyAdjustment);
 			assert.isTrue(OSApp.UIDom.areYouSure.notCalled);
+
+			var enabledWithoutPoints = baseBackup();
+			enabledWithoutPoints.programs.pd = [ program("Enabled without points", { flag: 1, uuid: 1, splits: [] }) ];
+			OSApp.ImportExport.importConfig(enabledWithoutPoints);
+			assert.isTrue(OSApp.UIDom.areYouSure.notCalled);
 			assert.isTrue(OSApp.Firmware.sendToOS.notCalled);
-			assert.equal(OSApp.Errors.showError.callCount, 4);
+			assert.equal(OSApp.Errors.showError.callCount, 5);
 		} finally {
 			sandbox.restore();
 			OSApp.currentSession.controller = controller;

--- a/test/tests/mutation_failure_checks.js
+++ b/test/tests/mutation_failure_checks.js
@@ -1,0 +1,87 @@
+/* eslint-disable */
+
+/* OpenSprinkler App
+ * Copyright (C) 2015 - present, Samer Albahra. All rights reserved.
+ *
+ * This file is part of the OpenSprinkler project <http://opensprinkler.com>.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3 as
+ * published by the Free Software Foundation.
+ */
+
+describe("Mutation Failure Checks", function () {
+	var sandbox;
+	var request;
+	var latestSites;
+
+	function resetStationAttributes() {
+		return OSApp.Options.resetStationAttributes("m0=255&");
+	}
+
+	beforeEach(function () {
+		sandbox = sinon.createSandbox();
+		request = $.Deferred();
+		latestSites = {
+			Yard: {
+				notes: { 0: "Keep until firmware succeeds" },
+				images: { 0: "station.jpg" },
+				lastRunTime: { 0: 1234 },
+				untouched: "preserve me"
+			},
+			Other: { untouched: "other site" }
+		};
+
+		sandbox.stub(OSApp.Storage, "get").callsFake(function (key, callback) {
+			if (key === "current_site") {
+				callback({ current_site: "Yard" });
+			} else if (key === "sites") {
+				callback({ sites: JSON.stringify(latestSites) });
+			}
+		});
+		sandbox.stub(OSApp.Storage, "set");
+		sandbox.stub(OSApp.Network, "cloudSaveSites");
+		sandbox.stub(OSApp.Firmware, "sendToOS").returns(request.promise());
+		sandbox.stub(OSApp.Sites, "updateController");
+		sandbox.stub(OSApp.Errors, "showError");
+		sandbox.stub($.mobile, "loading");
+	});
+
+	afterEach(function () {
+		sandbox.restore();
+	});
+
+	it("should preserve local station metadata when the firmware reset fails", function () {
+		resetStationAttributes();
+
+		assert.isTrue(OSApp.Storage.set.notCalled);
+		assert.isTrue(OSApp.Storage.get.calledOnceWith("current_site"));
+		assert.deepEqual(latestSites.Yard.notes, { 0: "Keep until firmware succeeds" });
+
+		request.reject({ status: 500 });
+
+		assert.isTrue(OSApp.Storage.set.notCalled);
+		assert.isTrue(OSApp.Sites.updateController.notCalled);
+		assert.isTrue(OSApp.Errors.showError.notCalled);
+		assert.deepEqual(latestSites.Yard.images, { 0: "station.jpg" });
+		assert.deepEqual(latestSites.Yard.lastRunTime, { 0: 1234 });
+	});
+
+	it("should clear only the target site's station metadata after firmware success", function () {
+		resetStationAttributes();
+
+		assert.isTrue(OSApp.Storage.set.notCalled);
+		request.resolve({ result: 1 });
+
+		assert.isTrue(OSApp.Storage.get.calledWith("sites"));
+		assert.isTrue(OSApp.Storage.set.calledOnce);
+		var storedSites = JSON.parse(OSApp.Storage.set.firstCall.args[0].sites);
+		assert.deepEqual(storedSites.Yard.notes, {});
+		assert.deepEqual(storedSites.Yard.images, {});
+		assert.deepEqual(storedSites.Yard.lastRunTime, {});
+		assert.equal(storedSites.Yard.untouched, "preserve me");
+		assert.deepEqual(storedSites.Other, { untouched: "other site" });
+		assert.isTrue(OSApp.Errors.showError.calledOnceWith("Stations have been updated"));
+		assert.isTrue(OSApp.Sites.updateController.calledOnce);
+	});
+});

--- a/test/tests/sensor_mutation_checks.js
+++ b/test/tests/sensor_mutation_checks.js
@@ -40,6 +40,59 @@ describe("Sensor Mutation Checks", function () {
 			});
 		});
 
+		it("should parse empty query segments and preserve embedded equals", function () {
+			assert.deepEqual(OSApp.Firmware.getUrlVars("/sn?pw=&"), { pw: "" });
+			assert.deepEqual(
+				OSApp.Firmware.getUrlVars("/sc?pw=&name=Tank=North&unit=L%2Fmin%2Bavg"),
+				{ pw: "", name: "Tank=North", unit: "L/min+avg" }
+			);
+		});
+
+		it("should POST clear-log requests without phantom parameters", function () {
+			checkOSVersion.returns(true);
+			ajaxq.callsFake(function () {
+				return $.Deferred().resolve({ deleted: 0 }).promise();
+			});
+
+			return OSApp.Firmware.sendToOS("/sn?pw=&").then(function () {
+				var request = ajaxq.firstCall.args[1];
+				assert.equal(ajaxq.firstCall.args[0], "change");
+				assert.equal(request.type, "POST");
+				assert.deepEqual(request.data, { pw: OSApp.currentSession.pass });
+			});
+		});
+
+		it("should round-trip encoded analog sensor text through POST data", function () {
+			var sensor = {
+				nr: 1,
+				type: OSApp.Analog.Constants.USERDEF_SENSOR,
+				group: 2,
+				name: "Tank=North & South+\u96ea",
+				ip: 0,
+				port: 80,
+				id: 3,
+				ri: 60,
+				fac: 1.5,
+				div: 2,
+				unit: "\u00b5S/cm=&+",
+				enable: 1,
+				log: 1,
+				show: 1
+			};
+			checkOSVersion.returns(true);
+			ajaxq.callsFake(function () {
+				return $.Deferred().resolve({ result: 1 }).promise();
+			});
+
+			return OSApp.Firmware.sendToOS(OSApp.Analog.buildSensorConfigCommand(sensor)).then(function () {
+				var request = ajaxq.firstCall.args[1];
+				assert.equal(ajaxq.firstCall.args[0], "change");
+				assert.equal(request.type, "POST");
+				assert.equal(request.data.name, sensor.name);
+				assert.equal(request.data.unit, sensor.unit);
+			});
+		});
+
 		[ "/csn?pw=&uuid=-1", "/dsn?pw=&uuid=7", "/dsl?pw=&uuid=7" ].forEach(function (endpoint) {
 			it("should reject firmware errors from " + endpoint.split("?")[0], function () {
 				return new Promise(function (resolve, reject) {

--- a/test/tests/sensor_mutation_checks.js
+++ b/test/tests/sensor_mutation_checks.js
@@ -33,6 +33,13 @@ describe("Sensor Mutation Checks", function () {
 			showError.restore();
 		});
 
+		[ "/sp?pw=&npw=new", "/pq?pw=&dur=60", "/dl?pw=&day=all", "/sa?pw=&nr=1", "/sc?pw=&nr=1",
+			"/sb?pw=&nr=1", "/sn?pw=" ].forEach(function (endpoint) {
+			it("should classify " + endpoint.split("?")[0] + " as a mutation", function () {
+				assert.isTrue(OSApp.Firmware.isChangeRequest(endpoint));
+			});
+		});
+
 		[ "/csn?pw=&uuid=-1", "/dsn?pw=&uuid=7", "/dsl?pw=&uuid=7" ].forEach(function (endpoint) {
 			it("should reject firmware errors from " + endpoint.split("?")[0], function () {
 				return new Promise(function (resolve, reject) {
@@ -91,6 +98,44 @@ describe("Sensor Mutation Checks", function () {
 						try {
 							assert.strictEqual(actual, error);
 							assert.equal(ajaxq.firstCall.args[0], "change");
+							resolve();
+						} catch (assertionError) {
+							reject(assertionError);
+						}
+					});
+			});
+		});
+
+		it("should show feedback for otherwise silent mutation transport failures", function () {
+			var error = { status: 500 };
+			ajaxq.callsFake(function () { return $.Deferred().reject(error).promise(); });
+
+			return new Promise(function (resolve, reject) {
+				OSApp.Firmware.sendToOS("/sp?pw=&npw=new&cpw=old", "json")
+					.done(function () { reject(new Error("Password transport failure was reported as success")); })
+					.fail(function (actual) {
+						try {
+							assert.strictEqual(actual, error);
+							assert.equal(ajaxq.firstCall.args[0], "change");
+							assert.isTrue(showError.calledOnceWith("Network Error"));
+							resolve();
+						} catch (assertionError) {
+							reject(assertionError);
+						}
+					});
+			});
+		});
+
+		it("should show feedback when a mutation endpoint is missing", function () {
+			ajaxq.callsFake(function () { return $.Deferred().resolve({ result: 32 }).promise(); });
+
+			return new Promise(function (resolve, reject) {
+				OSApp.Firmware.sendToOS("/sp?pw=&npw=new&cpw=old", "json")
+					.done(function () { reject(new Error("Missing mutation endpoint was reported as success")); })
+					.fail(function (actual) {
+						try {
+							assert.equal(actual.status, 404);
+							assert.isTrue(showError.calledOnceWith("Please check input and try again."));
 							resolve();
 						} catch (assertionError) {
 							reject(assertionError);

--- a/www/js/modules/analog.js
+++ b/www/js/modules/analog.js
@@ -110,6 +110,32 @@ OSApp.Analog.intFromBytes = function( x ) {
 	}
 };
 
+OSApp.Analog.buildSensorConfigCommand = function( sensor ) {
+	var params = new URLSearchParams();
+
+	params.append( "pw", "" );
+	params.append( "nr", sensor.nr );
+	params.append( "type", sensor.type );
+	params.append( "group", sensor.group );
+	params.append( "name", sensor.name );
+	params.append( "ip", sensor.ip );
+	params.append( "port", sensor.port );
+	params.append( "id", sensor.id );
+	params.append( "ri", sensor.ri );
+
+	if ( sensor.type === OSApp.Analog.Constants.USERDEF_SENSOR ) {
+		params.append( "fac", sensor.fac );
+		params.append( "div", sensor.div );
+		params.append( "unit", sensor.unit );
+	}
+
+	params.append( "enable", sensor.enable );
+	params.append( "log", sensor.log );
+	params.append( "show", sensor.show );
+
+	return "/sc?" + params.toString();
+};
+
 //Program adjustments editor
 OSApp.Analog.showAdjustmentsEditor = function( progAdjust, callback ) {
 
@@ -518,23 +544,7 @@ OSApp.Analog.showAnalogSensorConfig = ( function() {
 				sensorOut.nativedata = sensor.nativedata;
 				sensorOut.data = sensor.data;
 				sensorOut.last = sensor.last;
-				OSApp.Firmware.sendToOS( "/sc?pw=&nr=" + sensorOut.nr +
-					"&type=" + sensorOut.type +
-					"&group=" + sensorOut.group +
-					"&name=" + sensorOut.name +
-					"&ip=" + sensorOut.ip +
-					"&port=" + sensorOut.port +
-					"&id=" + sensorOut.id +
-					"&ri=" + sensorOut.ri +
-					( ( sensorOut.type === OSApp.Analog.Constants.USERDEF_SENSOR ) ?
-						( "&fac=" + sensorOut.fac +
-						"&div=" + sensorOut.div +
-						"&unit=" + sensorOut.unit
-						) : "" ) +
-					"&enable=" + sensorOut.enable +
-					"&log=" + sensorOut.log +
-					"&show=" + sensorOut.show
-				).done( function() {
+				OSApp.Firmware.sendToOS( OSApp.Analog.buildSensorConfigCommand( sensorOut ) ).done( function() {
 					OSApp.Analog.analogSensors[ row ] = sensorOut;
 					updateSensorContent();
 				} );
@@ -552,23 +562,7 @@ OSApp.Analog.showAnalogSensorConfig = ( function() {
 			};
 
 			OSApp.Analog.showSensorEditor( sensor, function( sensorOut ) {
-				OSApp.Firmware.sendToOS( "/sc?pw=&nr=" + sensorOut.nr +
-					"&type=" + sensorOut.type +
-					"&group=" + sensorOut.group +
-					"&name=" + sensorOut.name +
-					"&ip=" + sensorOut.ip +
-					"&port=" + sensorOut.port +
-					"&id=" + sensorOut.id +
-					"&ri=" + sensorOut.ri +
-				( ( sensorOut.type === OSApp.Analog.Constants.USERDEF_SENSOR ) ?
-					( "&fac=" + sensorOut.fac +
-					"&div=" + sensorOut.div +
-					"&unit=" + sensorOut.unit
-				) : "" ) +
-					"&enable=" + sensorOut.enable +
-					"&log=" + sensorOut.log +
-					"&show=" + sensorOut.show
-				).done( function() {
+				OSApp.Firmware.sendToOS( OSApp.Analog.buildSensorConfigCommand( sensorOut ) ).done( function() {
 					OSApp.Analog.analogSensors.push( sensorOut );
 					updateSensorContent();
 				} );
@@ -647,7 +641,7 @@ OSApp.Analog.showAnalogSensorConfig = ( function() {
 		// Clear sensor log
 		list.find( "#clear-log" ).on( "click", function() {
 			OSApp.UIDom.areYouSure( OSApp.Language._( "Are you sure you want to clear the sensor log?" ), "", function() {
-				OSApp.Firmware.sendToOS( "/sn?pw=&" ).done( function( result ) {
+				OSApp.Firmware.sendToOS( "/sn?pw=" ).done( function( result ) {
 					window.alert( OSApp.Language._( "Log cleared:" ) + " " + result.deleted + " " + OSApp.Language._( "records" ) );
 					updateSensorContent();
 				} );

--- a/www/js/modules/firmware.js
+++ b/www/js/modules/firmware.js
@@ -318,12 +318,26 @@ OSApp.Firmware.versionCompare = function( ver, check ) {
 
 OSApp.Firmware.getUrlVars = function( url ) {
 	var hash,
+		separator,
 		json = {},
-		hashes = url.slice( url.indexOf( "?" ) + 1 ).split( "&" );
+		queryIndex = url.indexOf( "?" ),
+		hashes = queryIndex === -1 ? [] : url.slice( queryIndex + 1 ).split( "&" );
 
 	for ( var i = 0; i < hashes.length; i++ ) {
-		hash = hashes[ i ].split( "=" );
-		json[ hash[ 0 ] ] = decodeURIComponent( hash[ 1 ].replace( /\+/g, "%20" ) );
+		hash = hashes[ i ];
+		if ( !hash ) {
+			continue;
+		}
+
+		separator = hash.indexOf( "=" );
+		if ( separator === -1 ) {
+			json[ hash ] = "";
+			continue;
+		}
+
+		json[ hash.slice( 0, separator ) ] = decodeURIComponent(
+			hash.slice( separator + 1 ).replace( /\+/g, "%20" )
+		);
 	}
 	return json;
 };

--- a/www/js/modules/firmware.js
+++ b/www/js/modules/firmware.js
@@ -39,7 +39,7 @@ OSApp.Firmware.Constants = {
 };
 
 OSApp.Firmware.isChangeRequest = function( dest ) {
-	return /\/(?:cv|cs|csn|cr|cp|uwa|dp|dsn|dsl|co|cl|cu|up|cm)(?:\?|$)/.test( dest );
+	return /\/(?:cv|cs|csn|cr|cp|uwa|dp|dsn|dsl|co|cl|cu|up|cm|sp|pq|dl|sa|sc|sb|sn)(?:\?|$)/.test( dest );
 };
 
 // Wrapper function to communicate with OpenSprinkler
@@ -121,6 +121,9 @@ OSApp.Firmware.sendToOS = function( dest, type ) {
 
 		// Handle page not found by triggering fail
 		} else if ( data.result === 32 ) {
+			if ( isChange ) {
+				OSApp.Errors.showError( OSApp.Language._( "Please check input and try again." ) );
+			}
 
 			return $.Deferred().reject( { "status":404 } );
 		}
@@ -231,6 +234,10 @@ OSApp.Firmware.sendToOS = function( dest, type ) {
 
 				//Handle unauthorized requests
 				OSApp.Errors.showError( OSApp.Language._( "Check device password and try again." ) );
+			} else if ( isChange ) {
+				// Ensure every rejected mutation replaces any active loader with
+				// visible feedback that will dismiss itself.
+				OSApp.Errors.showError( OSApp.Language._( "Network Error" ) );
 			}
 			// Preserve transport failure semantics for reads as well as writes. Callers
 			// must not treat a failed /jsn (or any other read) as resolved undefined.

--- a/www/js/modules/import-export.js
+++ b/www/js/modules/import-export.js
@@ -512,7 +512,8 @@ OSApp.ImportExport.importConfig = function( data ) {
 			return true;
 		}
 		if ( !Number.isInteger( adjustment.uuid ) || adjustment.uuid < 1 || adjustment.uuid > 65535 ||
-			!Array.isArray( adjustment.splits ) || adjustment.splits.length < 1 || adjustment.splits.length > 8 ) {
+			!Array.isArray( adjustment.splits ) || adjustment.splits.length > 8 ||
+			( ( adjustment.flag & 1 ) !== 0 && adjustment.splits.length < 1 ) ) {
 			return true;
 		}
 		var lastX = -Infinity;

--- a/www/js/modules/options.js
+++ b/www/js/modules/options.js
@@ -17,6 +17,35 @@
 var OSApp = OSApp || {};
 OSApp.Options = OSApp.Options || {};
 
+OSApp.Options.resetStationAttributes = function( attributes ) {
+	var operation = $.Deferred();
+
+	$.mobile.loading( "show" );
+	OSApp.Storage.get( "current_site", function( data ) {
+		var targetSite = data.current_site;
+
+		OSApp.Firmware.sendToOS( "/cs?pw=&" + attributes ).done( function( result ) {
+			OSApp.Storage.get( "sites", function( latestData ) {
+				var sites = OSApp.Sites.parseSites( latestData.sites );
+
+				if ( sites[ targetSite ] ) {
+					sites[ targetSite ].notes = {};
+					sites[ targetSite ].images = {};
+					sites[ targetSite ].lastRunTime = {};
+					OSApp.Storage.set( { "sites": JSON.stringify( sites ) }, () => OSApp.Network.cloudSaveSites() );
+				}
+				OSApp.Errors.showError( OSApp.Language._( "Stations have been updated" ) );
+				OSApp.Sites.updateController();
+				operation.resolve( result );
+			} );
+		} ).fail( function( error ) {
+			operation.reject( error );
+		} );
+	} );
+
+	return operation.promise();
+};
+
 // FIXME: please, please, please refactor me!
 // Device setting management functions
 OSApp.Options.showOptions = function( expandItem ) {
@@ -1369,20 +1398,7 @@ OSApp.Options.showOptions = function( expandItem ) {
 		}
 
 		OSApp.UIDom.areYouSure( OSApp.Language._( "Are you sure you want to reset station attributes?" ), OSApp.Language._( "This will reset all station attributes" ), function() {
-			$.mobile.loading( "show" );
-			OSApp.Storage.get( [ "sites", "current_site" ], function( data ) {
-				var sites = OSApp.Sites.parseSites( data.sites );
-
-				sites[ data.current_site ].notes = {};
-				sites[ data.current_site ].images = {};
-				sites[ data.current_site ].lastRunTime = {};
-
-				OSApp.Storage.set( { "sites": JSON.stringify( sites ) }, () => OSApp.Network.cloudSaveSites() );
-			} );
-			OSApp.Firmware.sendToOS( "/cs?pw=&" + cs ).done( function() {
-				OSApp.Errors.showError( OSApp.Language._( "Stations have been updated" ) );
-				OSApp.Sites.updateController();
-			} );
+			OSApp.Options.resetStationAttributes( cs );
 		} );
 	} );
 


### PR DESCRIPTION
## What changed

- allow backups containing a disabled selected sensor adjustment with zero split points to restore, while continuing to reject enabled adjustments without points
- classify the remaining legacy write endpoints as mutations and provide timed feedback for missing endpoints and transport failures
- preserve station notes, images, and last-run metadata unless the controller accepts the station-attribute reset, then merge the cleanup into the latest stored site data

## Why

The merged #294 code can produce a valid backup that its own importer rejects. Its corrected rejection semantics also exposed older write flows that only clean up on success, and Reset Station Attributes deleted local metadata before firmware confirmation.

This follows up on the [backup round-trip finding](https://github.com/OpenSprinkler/OpenSprinkler-App/pull/294#discussion_r3609677580) and [mutation cleanup finding](https://github.com/OpenSprinkler/OpenSprinkler-App/pull/294#discussion_r3609677585).

## Impact

The validation exception is limited to disabled adjustments. Existing successful mutation behavior is unchanged; failures now replace active loading indicators with a timed message. Local station metadata is cleared only after `/cs` succeeds.

## Validation

- `npm test` — 221 tests passed
- `npm run lint`
- `git diff --check`
