### PR TITLE
  Fix sensor log downloads in Android native app

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -99,6 +99,15 @@
                 <action android:name="android.intent.action.GET_CONTENT" />
             </intent>
         </config-file>
+        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+            <provider android:authorities="${applicationId}.sharing.provider"
+                android:exported="false"
+                android:grantUriPermissions="true"
+                android:name="nl.xservices.plugins.FileProvider">
+                <meta-data android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/sharing_paths" />
+            </provider>
+        </config-file>
         <preference name="Scheme" value="http" />
         <preference name="android-minSdkVersion" value="24" />
         <preference name="android-targetSdkVersion" value="35" />

--- a/test/tests/sensor_ui_checks.js
+++ b/test/tests/sensor_ui_checks.js
@@ -867,7 +867,9 @@ describe("Sensor UI Checks", function () {
 		var cordovaDescriptor = Object.getOwnPropertyDescriptor(window, "cordova");
 		var originalPlugins = window.plugins;
 		var originalResolver = window.resolveLocalFileSystemURL;
-		var shareWithOptions = sinon.spy();
+		var shareWithOptions = sinon.spy(function (_options, _success, error) {
+			error("Android chooser callback");
+		});
 		var truncate = sinon.spy(function () { this.onwriteend(); });
 		var write = sinon.spy(function () { this.onwriteend(); });
 		var writer = { truncate: truncate, write: write };
@@ -890,6 +892,8 @@ describe("Sensor UI Checks", function () {
 		var chartConstructor = sinon.stub(window, "Chart").returns(chart);
 		var loading = sinon.stub($.mobile, "loading");
 		var changeHeader = sinon.stub(OSApp.UIDom, "changeHeader");
+		var showError = sinon.stub(OSApp.Errors, "showError");
+		var consoleWarn = sinon.stub(console, "warn");
 		var sendToOS = sinon.stub(OSApp.Firmware, "sendToOS")
 			.returns($.Deferred().resolve(sensorLogBuffer()).promise());
 		var page;
@@ -906,6 +910,8 @@ describe("Sensor UI Checks", function () {
 			loading.restore();
 			chartConstructor.restore();
 			createObjectURL.restore();
+			showError.restore();
+			consoleWarn.restore();
 			window.plugins = originalPlugins;
 			window.resolveLocalFileSystemURL = originalResolver;
 			controller.settings.devt = originalDevt;
@@ -938,6 +944,8 @@ describe("Sensor UI Checks", function () {
 			assert.isTrue(shareWithOptions.calledOnce);
 			assert.deepEqual(shareWithOptions.firstCall.args[0].files, [ "file:///cache/sensor-exports/sensor.csv" ]);
 			assert.isFalse(createObjectURL.called);
+			assert.isTrue(consoleWarn.calledOnce);
+			assert.isTrue(showError.calledOnce);
 		} finally {
 			cleanup();
 		}

--- a/www/js/modules/sensors.js
+++ b/www/js/modules/sensors.js
@@ -2408,8 +2408,16 @@ OSApp.Sensors.displayLogs = function (_callback) {
         function writeAndShare(fileEntry) {
             fileEntry.createWriter((writer) => {
                 let cleared = false;
-                writer.onerror = showDownloadError;
+                let writeFailed = false;
+                writer.onerror = () => {
+                    writeFailed = true;
+                    console.warn("OS: FileWriter failed", writer.error);
+                    showDownloadError();
+                };
                 writer.onwriteend = () => {
+                    // Cordova FileWriter calls onwriteend after onerror.
+                    if (writeFailed) return;
+
                     // getFile({create:true}) does not truncate an existing file,
                     // so truncate first, then write on the second onwriteend.
                     if (!cleared) {
@@ -2426,7 +2434,10 @@ OSApp.Sensors.displayLogs = function (_callback) {
                         subject: filename,
                         files: [ fileUrl ],
                         chooserTitle: OSApp.Language._("Download Log")
-                    }, () => {}, showDownloadError);
+                    }, () => {}, (error) => {
+                        console.warn("OS: SocialSharing failed", error);
+                        showDownloadError();
+                    });
                 };
                 writer.truncate(0);
             }, showDownloadError);
@@ -2648,7 +2659,7 @@ OSApp.Sensors.displayLogs = function (_callback) {
         return OSApp.Sensors.fetchAllLogPages({
             collect: false,
             isCurrent: isCurrentContext,
-            onProgress: setLoadingProgress,
+            onProgress: (progress, processed) => setLoadingProgress(progress, processed, false),
             onPage: (buffer) => {
                 const rows = sensorLogCsvRows(buffer, sensorByUuid, unitByValue);
                 if (rows.length) csvParts.push(rows.join("\r\n") + "\r\n");
@@ -2662,8 +2673,9 @@ OSApp.Sensors.displayLogs = function (_callback) {
                     `sensorlog-${today}.csv`
                 );
             })
-            .fail(() => {
+            .fail((error) => {
 				if (!isCurrentContext()) return;
+                console.warn("OS: fetchAllLogPages failed", error);
                 OSApp.Errors.showError(OSApp.Language._("Failed to download sensor logs"));
             })
             .always(() => {


### PR DESCRIPTION
  ## Summary

  - Register the SocialSharing FileProvider required for Android CSV attachments.
  - Prevent file-writing failures from continuing into the share workflow.
  - Preserve error reporting and add targeted diagnostics for export failures.
  - Hide the nonfunctional Stop button during Download All.

  ## Testing

  - Verified per-sensor Download and Download All on an Android device.
  - Completed a clean Cordova Android build.
  - ESLint passes.
  - All 256 tests pass.
