### PR TITLE
  Add ASB compatibility handling and SN3/SN4 event support

### DIFF
--- a/test/tests/built_in_sensor_event_checks.js
+++ b/test/tests/built_in_sensor_event_checks.js
@@ -1,0 +1,54 @@
+/* eslint-disable */
+
+describe("Built-in Sensor Event Checks", function () {
+	it("discovers built-in sensors from option keys and assigns distinct labels", function () {
+		var sensors = OSApp.Sensors.getBuiltInSensors({
+			sn4t: 240,
+			sn2t: 3,
+			sn1t: 1,
+			sn3t: 0,
+			unrelated: 1
+		});
+
+		assert.deepEqual(sensors.map(function (sensor) { return sensor.code; }), [ "s1", "s2", "s3", "s4" ]);
+		assert.deepEqual(sensors.map(function (sensor) { return sensor.label; }), [
+			"Rain Sensor (SN1)",
+			"Soil Sensor (SN2)",
+			"Sensor (SN3)",
+			"Program Switch (SN4)"
+		]);
+	});
+
+	it("creates sprinkler-log metadata for every reported built-in sensor", function () {
+		var events = OSApp.Logs.getSensorLogEvents({ sn1t: 1, sn2t: 3, sn3t: 1, sn4t: 3 });
+
+		assert.equal(events.s1.label, "Rain Sensor (SN1)");
+		assert.equal(events.s2.label, "Soil Sensor (SN2)");
+		assert.equal(events.s3.label, "Rain Sensor (SN3)");
+		assert.equal(events.s4.label, "Soil Sensor (SN4)");
+	});
+
+	it("maps SN3 and SN4 notification events to their firmware bits", function () {
+		var events = OSApp.Options.getNotificationEvents({ sn3t: 0, sn4t: 0 });
+		var byID = {};
+		events.forEach(function (event) { byID[event.id] = event; });
+
+		assert.equal(byID.sensor1.bit, 1);
+		assert.equal(byID.sensor2.bit, 6);
+		assert.equal(byID.sensor3.bit, 11);
+		assert.equal(byID.sensor4.bit, 12);
+	});
+
+	it("hides unavailable sensor notification events and preserves unknown bits", function () {
+		var events = OSApp.Options.getNotificationEvents({});
+		var futureBit = 1 << 15;
+		var updated = OSApp.Options.updateNotificationEventValue(futureBit, events, function (event) {
+			return event.id === "sensor1";
+		});
+
+		assert.isUndefined(events.find(function (event) { return event.id === "sensor3"; }));
+		assert.isUndefined(events.find(function (event) { return event.id === "sensor4"; }));
+		assert.equal(updated & futureBit, futureBit);
+		assert.equal(updated & (1 << 1), 1 << 1);
+	});
+});

--- a/test/tests/site_refresh_checks.js
+++ b/test/tests/site_refresh_checks.js
@@ -19,6 +19,10 @@ describe("Site Refresh Checks", function () {
 		return $.Deferred().resolve(value).promise();
 	}
 
+	function rejected(error) {
+		return $.Deferred().reject(error).promise();
+	}
+
 	function stubInitialControllerRequests() {
 		[
 			"updateControllerPrograms",
@@ -146,6 +150,55 @@ describe("Site Refresh Checks", function () {
 		});
 	});
 
+	it("should skip official sensor endpoints during initial loading on ASB firmware", function () {
+		originalSession.controller = { options: { feature: "ASB", fwv: 240 } };
+		sandbox.stub(originalSession, "isControllerConnected").returns(false);
+		sandbox.stub(OSApp.Firmware, "checkOSVersion").returns(true);
+		stubInitialControllerRequests();
+		var updateSensors = sandbox.spy(OSApp.Sites, "updateControllerSensors");
+		var updateDescription = sandbox.spy(OSApp.Sites, "updateControllerSensorDescription");
+
+		return new Promise(function (resolve, reject) {
+			OSApp.Sites.updateController(function () {
+				try {
+					assert.isFalse(updateSensors.called);
+					assert.isFalse(updateDescription.called);
+					assert.isFalse(OSApp.Supported.sensors());
+					resolve();
+				} catch (error) {
+					reject(error);
+				}
+			}, reject);
+		});
+	});
+
+	it("should resolve ASB sensor helpers consistently without sending requests", function () {
+		var controller = {
+			options: { feature: "ASB", fwv: 240 },
+			sensors: { sn: [ { uuid: 7 } ] },
+			sensor_desc: { marker: "stale-description" }
+		};
+		originalSession.controller = controller;
+		var sendToOS = sandbox.spy(OSApp.Firmware, "sendToOS");
+
+		return new Promise(function (resolve, reject) {
+			OSApp.Sites.updateControllerSensors().then(function (sensors) {
+				assert.isNull(sensors);
+				return OSApp.Sites.updateControllerSensorDescription();
+			}).then(function (description) {
+				try {
+					assert.isNull(description);
+					assert.isUndefined(controller.sensors);
+					assert.isNull(controller.sensor_desc);
+					assert.isFalse(sendToOS.called);
+					resolve();
+				} catch (error) {
+					reject(error);
+				}
+			}, reject);
+		});
+	});
+
 	it("should merge connected controller data without replacing cached sensor fields", function () {
 		var request = $.Deferred();
 		var sensorDescription = { units: [ { value: 1, short: "V" } ] };
@@ -209,6 +262,112 @@ describe("Site Refresh Checks", function () {
 					assert.isTrue(sendToOS.calledWith("/ja?pw=", "json"));
 					assert.isTrue(sendToOS.calledWith("/jsd?pw=", "json"));
 					assert.isTrue(normalizeJsd.calledOnceWithExactly(rawDescription));
+					resolve();
+				} catch (error) {
+					reject(error);
+				}
+			}, reject);
+		});
+	});
+
+	it("should finish connected loading without repeatedly requesting an unavailable sensor description", function () {
+		var controller = {};
+		var fail = sandbox.spy();
+		originalSession.controller = controller;
+		sandbox.stub(originalSession, "isControllerConnected").returns(true);
+		sandbox.stub(OSApp.Firmware, "checkOSVersion").callsFake(function (version) { return version === 216; });
+		var sendToOS = sandbox.stub(OSApp.Firmware, "sendToOS").callsFake(function (path) {
+			if (path === "/ja?pw=") {
+				return resolved({
+					sensors: { sn: [ { uuid: 7, unit: 1 } ] },
+					status: { sn: [ 0 ] }
+				});
+			}
+			if (path === "/jsd?pw=") {
+				return rejected({ status: 404 });
+			}
+			return rejected(new Error("Unexpected request: " + path));
+		});
+
+		return new Promise(function (resolve, reject) {
+			OSApp.Sites.updateController(function () {
+				OSApp.Sites.updateController(function () {
+					try {
+						assert.deepEqual(controller.sensors, { sn: [ { uuid: 7, unit: 1 } ] });
+						assert.isNull(controller.sensor_desc);
+						assert.equal(sendToOS.withArgs("/jsd?pw=", "json").callCount, 1);
+						assert.isFalse(fail.called);
+						resolve();
+					} catch (error) {
+						reject(error);
+					}
+				}, function (error) {
+					fail(error);
+					reject(new Error("Optional sensor description was retried during controller loading"));
+				});
+			}, function (error) {
+				fail(error);
+				reject(new Error("Optional sensor description failed controller loading"));
+			});
+		});
+	});
+
+	it("should finish legacy loading when optional sensor endpoints are unavailable", function () {
+		var controller = {
+			sensors: { sn: [ { uuid: 7 } ] },
+			sensor_desc: { marker: "stale-description" }
+		};
+		var fail = sandbox.spy();
+		originalSession.controller = controller;
+		sandbox.stub(originalSession, "isControllerConnected").returns(false);
+		sandbox.stub(OSApp.Firmware, "checkOSVersion").returns(true);
+		stubInitialControllerRequests();
+		sandbox.stub(OSApp.Sites, "updateControllerSensors").returns(rejected({ status: 404 }));
+		sandbox.stub(OSApp.Sites, "updateControllerSensorDescription").returns(rejected({ status: 404 }));
+
+		return new Promise(function (resolve, reject) {
+			OSApp.Sites.updateController(function () {
+				try {
+					assert.isUndefined(controller.sensors);
+					assert.isNull(controller.sensor_desc);
+					assert.isFalse(fail.called);
+					resolve();
+				} catch (error) {
+					reject(error);
+				}
+			}, function (error) {
+				fail(error);
+				reject(new Error("Optional legacy sensor endpoints failed controller loading"));
+			});
+		});
+	});
+
+	it("should ignore official sensor data from a connected ASB /ja response", function () {
+		var controller = {
+			options: { feature: "ASB", fwv: 240 },
+			sensor_desc: { marker: "stale-description" }
+		};
+		originalSession.controller = controller;
+		sandbox.stub(originalSession, "isControllerConnected").returns(true);
+		sandbox.stub(OSApp.Firmware, "checkOSVersion").returns(true);
+		var sendToOS = sandbox.stub(OSApp.Firmware, "sendToOS").callsFake(function (path) {
+			if (path === "/ja?pw=") {
+				return resolved({
+					options: { feature: "ASB", fwv: 240 },
+					sensors: { sn: [ { uuid: 7 } ] },
+					status: { sn: [ 0 ] }
+				});
+			}
+			return $.Deferred().reject(new Error("Unexpected request: " + path)).promise();
+		});
+
+		return new Promise(function (resolve, reject) {
+			OSApp.Sites.updateController(function () {
+				try {
+					assert.isUndefined(controller.sensors);
+					assert.isUndefined(controller.sensor_desc);
+					assert.isFalse(OSApp.Supported.sensors());
+					assert.isTrue(sendToOS.calledOnceWithExactly("/ja?pw=", "json"));
 					resolve();
 				} catch (error) {
 					reject(error);

--- a/test/tests/site_refresh_checks.js
+++ b/test/tests/site_refresh_checks.js
@@ -312,6 +312,46 @@ describe("Site Refresh Checks", function () {
 		});
 	});
 
+	[
+		{ name: "authentication", error: { status: 401 } },
+		{ name: "server", error: { status: 500 } },
+		{ name: "timeout", error: { status: 0, statusText: "timeout" } }
+	].forEach(function (testCase) {
+		it("should propagate " + testCase.name + " failures from the sensor description request", function () {
+			var controller = {};
+			originalSession.controller = controller;
+			sandbox.stub(originalSession, "isControllerConnected").returns(true);
+			sandbox.stub(OSApp.Firmware, "checkOSVersion").callsFake(function (version) { return version === 216; });
+			sandbox.stub(OSApp.Firmware, "sendToOS").callsFake(function (path) {
+				if (path === "/ja?pw=") {
+					return resolved({
+						sensors: { sn: [ { uuid: 7, unit: 1 } ] },
+						status: { sn: [ 0 ] }
+					});
+				}
+				if (path === "/jsd?pw=") {
+					return rejected(testCase.error);
+				}
+				return rejected(new Error("Unexpected request: " + path));
+			});
+
+			return new Promise(function (resolve, reject) {
+				OSApp.Sites.updateController(function () {
+					reject(new Error("Sensor-description failure was reported as success"));
+				}, function (error) {
+					try {
+						assert.strictEqual(error, testCase.error);
+						assert.deepEqual(controller.sensors, { sn: [ { uuid: 7, unit: 1 } ] });
+						assert.isUndefined(controller.sensor_desc);
+						resolve();
+					} catch (assertionError) {
+						reject(assertionError);
+					}
+				});
+			});
+		});
+	});
+
 	it("should finish legacy loading when optional sensor endpoints are unavailable", function () {
 		var controller = {
 			sensors: { sn: [ { uuid: 7 } ] },
@@ -338,6 +378,34 @@ describe("Site Refresh Checks", function () {
 			}, function (error) {
 				fail(error);
 				reject(new Error("Optional legacy sensor endpoints failed controller loading"));
+			});
+		});
+	});
+
+	it("should propagate server failures from legacy sensor endpoints without clearing cached data", function () {
+		var sensors = { sn: [ { uuid: 7 } ] };
+		var sensorDescription = { marker: "cached-description" };
+		var controller = { sensors: sensors, sensor_desc: sensorDescription };
+		var error = { status: 500 };
+		originalSession.controller = controller;
+		sandbox.stub(originalSession, "isControllerConnected").returns(false);
+		sandbox.stub(OSApp.Firmware, "checkOSVersion").returns(true);
+		stubInitialControllerRequests();
+		sandbox.stub(OSApp.Sites, "updateControllerSensors").returns(rejected(error));
+		sandbox.stub(OSApp.Sites, "updateControllerSensorDescription").returns(rejected(error));
+
+		return new Promise(function (resolve, reject) {
+			OSApp.Sites.updateController(function () {
+				reject(new Error("Sensor endpoint failure was reported as success"));
+			}, function (failure) {
+				try {
+					assert.strictEqual(failure, error);
+					assert.strictEqual(controller.sensors, sensors);
+					assert.strictEqual(controller.sensor_desc, sensorDescription);
+					resolve();
+				} catch (assertionError) {
+					reject(assertionError);
+				}
 			});
 		});
 	});

--- a/test/tests/site_rendering_checks.js
+++ b/test/tests/site_rendering_checks.js
@@ -14,6 +14,91 @@
  */
 
 describe( "Site Rendering Checks", function() {
+	it( "adds a persistent ASB compatibility notification", function() {
+		var sandbox = sinon.createSandbox(),
+			originalController = OSApp.currentSession.controller;
+
+		try {
+			OSApp.currentSession.controller = { options: { feature: "ASB" } };
+			var addNotification = sandbox.stub( OSApp.Notifications, "addNotification" );
+			var changePage = sandbox.stub( OSApp.UIDom, "changePage" );
+
+			OSApp.Sites.addASBCompatibilityNotification();
+			assert.isTrue( addNotification.calledOnce );
+			assert.equal( addNotification.firstCall.args[ 0 ].title, "ASB firmware detected" );
+			assert.equal( addNotification.firstCall.args[ 0 ].desc, "This UI has limited support for it. Switch to OpenSprinklerASB app/UI." );
+
+			assert.isFalse( addNotification.firstCall.args[ 0 ].on() );
+			assert.isTrue( changePage.calledOnceWithExactly( "#about" ) );
+		} finally {
+			OSApp.currentSession.controller = originalController;
+			sandbox.restore();
+		}
+	} );
+
+	it( "shows the ASB compatibility notice once per site", function() {
+		var sandbox = sinon.createSandbox(),
+			originalController = OSApp.currentSession.controller,
+			dismissed = false,
+			popup;
+
+		try {
+			OSApp.currentSession.controller = { options: { feature: "ASB" } };
+			sandbox.stub( OSApp.Storage, "get" ).callsFake( function( key, callback ) {
+				var data = {};
+				data[ key ] = dismissed ? "1" : null;
+				callback( data );
+			} );
+			sandbox.stub( OSApp.Storage, "set" ).callsFake( function( data ) {
+				dismissed = Object.values( data )[ 0 ] === "1";
+			} );
+			sandbox.stub( OSApp.UIDom, "openPopup" ).callsFake( function( renderedPopup ) {
+				popup = renderedPopup;
+			} );
+			sandbox.stub( $.fn, "popup" ).returnsThis();
+
+			OSApp.Sites.showASBCompatibilityNotice( "ASB Test Site" );
+			assert.equal( popup.find( "h3" ).text(), "OpenSprinklerASB Firmware Detected" );
+			assert.equal(
+				popup.find( "p" ).text(),
+				"Your device runs the OpenSprinklerASB firmware. This UI has limited support for it. Please switch to the OpenSprinklerASB mobile app/UI for full support."
+			);
+			assert.equal( popup.find( ".ui-btn" ).text(), "Continue" );
+
+			popup.find( ".ui-btn" ).trigger( "click" );
+			assert.isTrue( dismissed );
+
+			OSApp.Sites.showASBCompatibilityNotice( "ASB Test Site" );
+			assert.isTrue( OSApp.UIDom.openPopup.calledOnce );
+		} finally {
+			OSApp.currentSession.controller = originalController;
+			sandbox.restore();
+		}
+	} );
+
+	it( "shows limited ASB compatibility on the About page", function() {
+		var sandbox = sinon.createSandbox(),
+			originalController = OSApp.currentSession.controller;
+
+		try {
+			OSApp.currentSession.controller = {
+				options: { feature: "ASB", fwv: 240, fwm: 0, hwv: "ASB" }
+			};
+			sandbox.stub( OSApp.UIDom, "changeHeader" );
+
+			OSApp.About.displayPage();
+			assert.isFalse( $( "#about .asbCompatibility" ).hasClass( "hidden" ) );
+			assert.equal(
+				$( "#about .asb-compatibility-warning" ).text(),
+				"This UI has limited support for ASB firmware."
+			);
+		} finally {
+			$( "#about" ).remove();
+			OSApp.currentSession.controller = originalController;
+			sandbox.restore();
+		}
+	} );
+
 	it( "renders an auto-discovered address as an input value", function() {
 		var sandbox = sinon.createSandbox(),
 			autoIP = "192.168.1.2' onfocus='window.siteAddressInjected=true";

--- a/www/css/main.css
+++ b/www/css/main.css
@@ -780,6 +780,18 @@ input[type=number] {
     white-space:normal
 }
 
+.asb-compatibility-warning {
+    color: #8b1e2d;
+    font-style: italic;
+}
+
+.asb-compatibility-popup {
+    box-sizing: border-box;
+    max-width: 90vw;
+    padding: 1em;
+    width: 420px;
+}
+
 /* Home page rules */
 #footer-running {
     font-weight:400;

--- a/www/js/modules/about.js
+++ b/www/js/modules/about.js
@@ -59,6 +59,10 @@ OSApp.About.displayPage = function() {
 					${OSApp.Language._("App Version")}: ${OSApp.uiState.appVersion}
 					<br>
 					${OSApp.Language._("Firmware")}: <span class="firmware"></span>
+					<span class="asbCompatibility hidden">
+						<br>
+						<span class="asb-compatibility-warning"></span>
+					</span>
 					<br>
 					<span class="hardwareLabel">${OSApp.Language._("Hardware Version")}:</span> <span class="hardware"></span>
 				</p>
@@ -73,6 +77,10 @@ OSApp.About.displayPage = function() {
 		page.find( ".hardwareLabel" ).toggleClass( "hidden", showHardware );
 
 		page.find( ".firmware" ).text( OSApp.Firmware.getOSVersion() + OSApp.Firmware.getOSMinorVersion() + ( OSApp.Analog.checkAnalogSensorAvail() ? " - ASB" : "" ) );
+		page.find( ".asbCompatibility" ).toggleClass( "hidden", !OSApp.Analog.checkAnalogSensorAvail() )
+			.find( ".asb-compatibility-warning" ).text(
+				OSApp.Language._( "This UI has limited support for ASB firmware." )
+			);
 
 		page.one( "pagehide", function() {
 			page.detach();

--- a/www/js/modules/analog.js
+++ b/www/js/modules/analog.js
@@ -20,8 +20,9 @@ OSApp.Analog = {
 	}
 };
 
-OSApp.Analog.checkAnalogSensorAvail = function() {
-	return OSApp.currentSession.controller.options && OSApp.currentSession.controller.options.feature === "ASB";
+OSApp.Analog.checkAnalogSensorAvail = function( controller ) {
+	controller = controller || OSApp.currentSession.controller;
+	return controller?.options?.feature === "ASB";
 };
 
 OSApp.Analog.refresh = function() {

--- a/www/js/modules/logs.js
+++ b/www/js/modules/logs.js
@@ -17,6 +17,14 @@
 var OSApp = OSApp || {};
 OSApp.Logs = OSApp.Logs || {};
 
+OSApp.Logs.getSensorLogEvents = function( options ) {
+	var events = {};
+	OSApp.Sensors.getBuiltInSensors( options ).forEach( function( sensor ) {
+		events[ sensor.code ] = sensor;
+	} );
+	return events;
+};
+
 OSApp.Logs.displayPage = function() {
 	// Build the log page and add it to DOM
 	var page = $(`
@@ -61,6 +69,8 @@ OSApp.Logs.displayPage = function() {
 		groups = [],
 		waterlog = [],
 		flowlog = [],
+		logEvents = {},
+		stationCount = 0,
 		sortData = function( type, grouping ) {
 
 			var sortedData = [],
@@ -77,6 +87,7 @@ OSApp.Logs.displayPage = function() {
 
 			$.each( data, function() {
 				var station = this[ 1 ],
+					logEvent = typeof station === "string" ? logEvents[ station ] : null,
 					duration = parseInt( this[ 2 ] ),
 					flowRate = ( typeof this[ 4 ] !== "undefined" ) ? OSApp.Utils.flowRateToVolume( parseFloat( this[ 4 ] ) ) : null;
 
@@ -90,19 +101,12 @@ OSApp.Logs.displayPage = function() {
 						date.getUTCMinutes(), date.getUTCSeconds() );
 
 				if ( typeof station === "string" ) {
-					if ( station === "rd" ) {
-						station = stations.length - 1;
-					} else if ( station === "s1" ) {
-						station = stations.length - 3;
-					} else if ( station === "s2" ) {
-						station = stations.length - 2;
-					} else if ( station === "rs" ) {
-						station = stations.length - 2;
-					} else {
+					if ( !logEvent ) {
 						return;
 					}
+					station = logEvent.index;
 				} else if ( typeof station === "number" ) {
-					if ( station > stations.length - 2 || OSApp.Stations.isMaster( station ) ) {
+					if ( station < 0 || station >= stationCount || OSApp.Stations.isMaster( station ) ) {
 						return;
 					}
 
@@ -136,21 +140,9 @@ OSApp.Logs.displayPage = function() {
 					var pid = parseInt( this[ 0 ] ),
 						className, name, group;
 
-					if ( this[ 1 ] === "rs" ) {
+					if ( logEvent ) {
 						className = "delayed";
-						name = OSApp.Language._( "Rain Sensor" );
-						group = name;
-					} else if ( this[ 1 ] === "rd" ) {
-						className = "delayed";
-						name = OSApp.Language._( "Rain Delay" );
-						group = name;
-					} else if ( this[ 1 ] === "s1" ) {
-						className = "delayed";
-						name = OSApp.currentSession.controller.options.sn1t === 3 ? OSApp.Language._( "Soil Sensor" ) : OSApp.Language._( "Rain Sensor" );
-						group = name;
-					} else if ( this[ 1 ] === "s2" ) {
-						className = "delayed";
-						name = OSApp.currentSession.controller.options.sn2t === 3 ? OSApp.Language._( "Soil Sensor" ) : OSApp.Language._( "Rain Sensor" );
+						name = logEvent.label;
 						group = name;
 					} else if ( pid === 0 ) {
 						return;
@@ -602,13 +594,34 @@ OSApp.Logs.displayPage = function() {
 	page.find( "#log_table" ).prop( "checked", isNarrow );
 
 	function begin() {
-		var additionalMetrics = OSApp.Firmware.checkOSVersion( 219 ) ? [
-			OSApp.currentSession.controller.options.sn1t === 3 ? OSApp.Language._( "Soil Sensor" ) : OSApp.Language._( "Rain Sensor" ),
-			OSApp.currentSession.controller.options.sn2t === 3 ? OSApp.Language._( "Soil Sensor" ) : OSApp.Language._( "Rain Sensor" ),
-			OSApp.Language._( "Rain Delay" )
-		] : [ OSApp.Language._( "Rain Sensor" ), OSApp.Language._( "Rain Delay" ) ];
+		var stationNames = OSApp.currentSession.controller.stations?.snames || [],
+			additionalMetrics = [],
+			addLogEvent = function( code, label ) {
+				logEvents[ code ] = {
+					index: stationCount + additionalMetrics.length,
+					label: label
+				};
+				additionalMetrics.push( label );
+			};
 
-		stations = $.merge( $.merge( [], OSApp.currentSession.controller.stations?.snames ), additionalMetrics );
+		stationCount = stationNames.length;
+		logEvents = {};
+		if ( OSApp.Firmware.checkOSVersion( 219 ) ) {
+			var sensorEvents = OSApp.Logs.getSensorLogEvents( OSApp.currentSession.controller.options );
+			Object.keys( sensorEvents ).forEach( function( code ) {
+				addLogEvent( code, sensorEvents[ code ].label );
+			} );
+			if ( logEvents.s1 ) {
+				logEvents.rs = logEvents.s1;
+			} else {
+				addLogEvent( "rs", OSApp.Language._( "Rain Sensor" ) );
+			}
+		} else {
+			addLogEvent( "rs", OSApp.Language._( "Rain Sensor" ) );
+		}
+		addLogEvent( "rd", OSApp.Language._( "Rain Delay" ) );
+
+		stations = $.merge( $.merge( [], stationNames ), additionalMetrics );
 		page.find( ".clear_logs" ).toggleClass( "hidden", ( OSApp.Firmware.isOSPi() || OSApp.Firmware.checkOSVersion( 210 ) ?  false : true ) );
 
 		if ( logStart.val() === "" || logEnd.val() === "" ) {

--- a/www/js/modules/options.js
+++ b/www/js/modules/options.js
@@ -17,6 +17,44 @@
 var OSApp = OSApp || {};
 OSApp.Options = OSApp.Options || {};
 
+OSApp.Options.getNotificationEvents = function( options ) {
+	options = options || {};
+	var events = [
+		{ id: "program", bit: 0, label: OSApp.Language._( "Program Start" ) },
+		{ id: "sensor1", bit: 1, label: OSApp.Language._( "Sensor 1 Update" ) },
+		{ id: "flow", bit: 2, label: OSApp.Language._( "Flow Sensor Update" ) },
+		{ id: "weather", bit: 3, label: OSApp.Language._( "Weather Adjustment Update" ) },
+		{ id: "reboot", bit: 4, label: OSApp.Language._( "Controller Reboot" ) },
+		{ id: "run", bit: 5, label: OSApp.Language._( "Station Finish" ) },
+		{ id: "sensor2", bit: 6, label: OSApp.Language._( "Sensor 2 Update" ) },
+		{ id: "rain", bit: 7, label: OSApp.Language._( "Rain Delay Update" ) },
+		{ id: "station", bit: 8, label: OSApp.Language._( "Station Start" ) },
+		{ id: "flow_alert", bit: 9, label: OSApp.Language._( "Flow Alert" ) },
+		{ id: "curr_alert", bit: 10, label: OSApp.Language._( "Under/Overcurrent Fault" ) },
+		{ id: "sensor3", bit: 11, label: OSApp.Language._( "Sensor 3 Update" ), option: "sn3t" },
+		{ id: "sensor4", bit: 12, label: OSApp.Language._( "Sensor 4 Update" ), option: "sn4t" }
+	];
+
+	return events.filter( function( event ) {
+		return !event.option || typeof options[ event.option ] !== "undefined";
+	} );
+};
+
+OSApp.Options.updateNotificationEventValue = function( value, events, getSelection ) {
+	events.forEach( function( event ) {
+		var selected = getSelection( event );
+		if ( typeof selected !== "boolean" ) {
+			return;
+		}
+		if ( selected ) {
+			value |= 1 << event.bit;
+		} else {
+			value &= ~( 1 << event.bit );
+		}
+	} );
+	return value;
+};
+
 OSApp.Options.resetStationAttributes = function( attributes ) {
 	var operation = $.Deferred();
 
@@ -1597,26 +1635,16 @@ OSApp.Options.showOptions = function( expandItem ) {
 	} );
 
 	page.find( "#o49" ).on( "click", function() {
-		var events = {
-			program: OSApp.Language._( "Program Start" ),
-			sensor1: OSApp.Language._( "Sensor 1 Update" ),
-			flow: OSApp.Language._( "Flow Sensor Update" ),
-			weather: OSApp.Language._( "Weather Adjustment Update" ),
-			reboot: OSApp.Language._( "Controller Reboot" ),
-			run: OSApp.Language._( "Station Finish" ),
-			sensor2: OSApp.Language._( "Sensor 2 Update" ),
-			rain: OSApp.Language._( "Rain Delay Update" ),
-			station: OSApp.Language._( "Station Start" ),
-			flow_alert: OSApp.Language._( "Flow Alert" ),
-			curr_alert: OSApp.Language._( "Under/Overcurrent Fault" ),
-		}, button = this, curr = parseInt( button.value ), inputs = "", a = 0, ife = 0;
+		var events = OSApp.Options.getNotificationEvents( OSApp.currentSession.controller.options ),
+			button = this,
+			curr = parseInt( button.value ),
+			inputs = "";
 
 		let no_ife2 = typeof OSApp.currentSession.controller.options.ife2 === "undefined";
-		$.each( events, function( i, val ) {
-			inputs += "<label for='notif-" + i + "'><input class='needsclick' data-iconpos='right' id='notif-" + i + "' type='checkbox' " +
-				( OSApp.Utils.getBitFromByte( curr, a ) ? "checked='checked'" : "" ) + ( no_ife2 && a >= 8 ? " disabled" : "" ) + ">" + val +
+		events.forEach( function( event ) {
+			inputs += "<label for='notif-" + event.id + "'><input class='needsclick' data-iconpos='right' id='notif-" + event.id + "' type='checkbox' " +
+				( OSApp.Utils.getBitFromByte( curr, event.bit ) ? "checked='checked'" : "" ) + ( no_ife2 && event.bit >= 8 ? " disabled" : "" ) + ">" + event.label +
 			"</label>";
-			a++;
 		} );
 
 		var popup = $(
@@ -1629,10 +1657,12 @@ OSApp.Options.showOptions = function( expandItem ) {
 			"</div>" );
 
 		popup.find( ".submit" ).on( "click", function() {
-			a = 0;
-			$.each( events, function( i ) {
-				ife |= popup.find( "#notif-" + i ).is( ":checked" ) << a;
-				a++;
+			var ife = OSApp.Options.updateNotificationEventValue( curr, events, function( event ) {
+				var input = popup.find( "#notif-" + event.id );
+				if ( input.is( ":disabled" ) ) {
+					return undefined;
+				}
+				return input.is( ":checked" );
 			} );
 			popup.popup( "close" );
 

--- a/www/js/modules/sensors.js
+++ b/www/js/modules/sensors.js
@@ -92,6 +92,38 @@ OSApp.Sensors = {};
 // Status bitfield reported by /jsn for each sensor.
 OSApp.Sensors.STATUS = { VALID: 1, ERROR: 2, STALE: 4, CLAMPED_HIGH: 8, CLAMPED_LOW: 16 };
 
+OSApp.Sensors.getBuiltInSensorTypeName = function( type, shortName ) {
+	var names = {
+		1: [ OSApp.Language._( "Rain" ), OSApp.Language._( "Rain Sensor" ) ],
+		2: [ OSApp.Language._( "Flow" ), OSApp.Language._( "Flow Sensor" ) ],
+		3: [ OSApp.Language._( "Soil" ), OSApp.Language._( "Soil Sensor" ) ],
+		240: [ OSApp.Language._( "Program Switch" ), OSApp.Language._( "Program Switch" ) ]
+	};
+	var name = names[ type ] || [ OSApp.Language._( "Sensor" ), OSApp.Language._( "Sensor" ) ];
+	return name[ shortName ? 0 : 1 ];
+};
+
+OSApp.Sensors.getBuiltInSensors = function( options ) {
+	return Object.keys( options || {} ).map( function( key ) {
+		var match = /^sn(\d+)t$/.exec( key );
+		if ( !match ) {
+			return null;
+		}
+
+		var number = parseInt( match[ 1 ] );
+		return {
+			number: number,
+			code: "s" + number,
+			type: options[ key ],
+			label: OSApp.Sensors.getBuiltInSensorTypeName( options[ key ] ) + " (SN" + number + ")"
+		};
+	} ).filter( function( sensor ) {
+		return sensor !== null;
+	} ).sort( function( a, b ) {
+		return a.number - b.number;
+	} );
+};
+
 // Format a sensor reading for display. Returns text + a CSS class name driven
 // by the sensor status bitfield. Used by both the Edit Sensors page and the
 // homepage show-on-home cards.

--- a/www/js/modules/sites.js
+++ b/www/js/modules/sites.js
@@ -931,6 +931,7 @@ OSApp.Sites.newLoad = function() {
 			if ( OSApp.Analog.checkAnalogSensorAvail() ) {
 				OSApp.Analog.updateAnalogSensor();
 				OSApp.Analog.updateProgramAdjustments();
+				OSApp.Sites.addASBCompatibilityNotification();
 			}
 
 			// Hide change password feature for unsupported devices
@@ -976,6 +977,16 @@ OSApp.Sites.newLoad = function() {
 			if ( OSApp.currentSession.controller.options.firstRun ) {
 				OSApp.Sites.showGuidedSetup();
 			} else {
+				if ( OSApp.Analog.checkAnalogSensorAvail() ) {
+					$.mobile.document.off( "pageshow.asbCompatibility", "#sprinklers" );
+					if ( $( ".ui-page-active" ).attr( "id" ) === "sprinklers" ) {
+						OSApp.Sites.showASBCompatibilityNotice( name );
+					} else {
+						$.mobile.document.one( "pageshow.asbCompatibility", "#sprinklers", function() {
+							OSApp.Sites.showASBCompatibilityNotice( name );
+						} );
+					}
+				}
 				OSApp.UIDom.goHome( true );
 			}
 		},
@@ -1019,6 +1030,58 @@ OSApp.Sites.newLoad = function() {
 			}
 		}
 	);
+};
+
+OSApp.Sites.addASBCompatibilityNotification = function() {
+	if ( !OSApp.Analog.checkAnalogSensorAvail() ) {
+		return;
+	}
+
+	OSApp.Notifications.addNotification( {
+		title: OSApp.Language._( "ASB firmware detected" ),
+		desc: OSApp.Language._( "This UI has limited support for it. Switch to OpenSprinklerASB app/UI." ),
+		on: function() {
+			OSApp.UIDom.changePage( "#about" );
+			return false;
+		}
+	} );
+};
+
+OSApp.Sites.showASBCompatibilityNotice = function( siteName ) {
+	if ( !OSApp.Analog.checkAnalogSensorAvail() ) {
+		return;
+	}
+
+	var identity = siteName || OSApp.currentSession.token || OSApp.currentSession.ip || "local",
+		storageKey = "asbCompatibilityDismissed:" + encodeURIComponent( identity );
+
+	OSApp.Storage.get( storageKey, function( data ) {
+		if ( data[ storageKey ] === "1" || !OSApp.Analog.checkAnalogSensorAvail() ) {
+			return;
+		}
+
+		var popup = $( "<div data-role='popup' data-theme='a' data-dismissible='false' class='asb-compatibility-popup'></div>" ),
+			title = $( "<h3 class='center'></h3>" ).text(
+				OSApp.Language._( "OpenSprinklerASB Firmware Detected" )
+			),
+			message = $( "<p></p>" ).text(
+				OSApp.Language._( "Your device runs the OpenSprinklerASB firmware. This UI has limited support for it. Please switch to the OpenSprinklerASB mobile app/UI for full support." )
+			),
+			continueButton = $( "<a class='ui-btn ui-btn-b ui-corner-all ui-shadow' href='#'></a>" ).text(
+				OSApp.Language._( "Continue" )
+			);
+
+		continueButton.one( "click", function() {
+			var dismissed = {};
+			dismissed[ storageKey ] = "1";
+			OSApp.Storage.set( dismissed );
+			popup.popup( "close" );
+			return false;
+		} );
+
+		popup.append( title, message, continueButton );
+		OSApp.UIDom.openPopup( popup );
+	} );
 };
 
 // Update controller information
@@ -1071,6 +1134,20 @@ OSApp.Sites.updateController = function( callback, fail ) {
 			fail( error );
 		}
 	};
+	var allowOptionalSensorFailure = function( request, clearUnavailableData ) {
+		var optionalRequest = $.Deferred();
+		request.then( function( data ) {
+			optionalRequest.resolve( data );
+		}, function( error ) {
+			if ( OSApp.Sites.isStaleControllerRefresh( error ) ) {
+				optionalRequest.reject( error );
+				return;
+			}
+			clearUnavailableData();
+			optionalRequest.resolve( null );
+		} );
+		return optionalRequest.promise();
+	};
 
 	if ( session.isControllerConnected() && OSApp.Firmware.checkOSVersion( 216 ) ) {
 		OSApp.Firmware.sendToOS( "/ja?pw=", "json" ).then( function( data ) {
@@ -1087,14 +1164,26 @@ OSApp.Sites.updateController = function( callback, fail ) {
 			// from separate endpoints (special, sensor_desc, jpaData) are preserved automatically.
 			$.extend( controller, data );
 
+			// Stefan's ASB firmware (feature "ASB") implements its own analog sensor
+			// endpoints (/sl, /se, /sa) instead of the upstream sensor system
+			// (/jsn, /jsd, /jsl). Drop any sensor payload so the app falls back to
+			// the legacy analog UI and never queries the unsupported endpoints.
+			if ( !OSApp.Supported.officialSensorAPIAllowed( controller ) ) {
+				delete controller.sensors;
+				delete controller.sensor_desc;
+			}
+
 			// Fix the station status array
 			controller.status = controller.status.sn;
 
 			// /ja includes live sensor data, but the firmware intentionally keeps
 			// the larger sensor-description schema on /jsd. Prime that schema on
 			// first load so unit labels and sensor controls are immediately ready.
-			if ( Array.isArray( controller.sensors?.sn ) && !controller.sensor_desc ) {
-				OSApp.Sites.updateControllerSensorDescription( undefined, context ).then( finish, failCurrent );
+			if ( Array.isArray( controller.sensors?.sn ) && typeof controller.sensor_desc === "undefined" ) {
+				allowOptionalSensorFailure(
+					OSApp.Sites.updateControllerSensorDescription( undefined, context ),
+					function() { controller.sensor_desc = null; }
+				).then( finish, failCurrent );
 			} else {
 				finish();
 			}
@@ -1110,10 +1199,16 @@ OSApp.Sites.updateController = function( callback, fail ) {
 			if ( !isCurrentContext() ) {
 				return;
 			}
-			if ( OSApp.Firmware.checkOSVersion( 2215 ) ) {
+			if ( OSApp.Supported.legacySensorEndpoints( controller ) ) {
 				$.when(
-					OSApp.Sites.updateControllerSensors( undefined, context ),
-					OSApp.Sites.updateControllerSensorDescription( undefined, context ),
+					allowOptionalSensorFailure(
+						OSApp.Sites.updateControllerSensors( undefined, context ),
+						function() { delete controller.sensors; }
+					),
+					allowOptionalSensorFailure(
+						OSApp.Sites.updateControllerSensorDescription( undefined, context ),
+						function() { controller.sensor_desc = null; }
+					),
 				).then( finish, failCurrent );
 			} else {
 				finish();
@@ -1442,6 +1537,17 @@ OSApp.Sites.updateControllerSensors = function( callback, expectedContext ) {
 		controller.sensors = { sn: [] };
 		callback();
 		return $.Deferred().resolve( controller.sensors ).promise();
+	} else if ( !OSApp.Supported.officialSensorAPIAllowed( controller ) ) {
+
+		// ASB firmware uses its own analog endpoints (/sl, /se, /sa); the upstream
+		// sensor endpoints (/jsn, /jsd) do not exist. Resolve null so callers and
+		// OSApp.Supported.sensors() treat the sensor system as unavailable.
+		if ( !isCurrentContext() ) {
+			return rejectStaleSiteControllerRefresh();
+		}
+		delete controller.sensors;
+		callback();
+		return $.Deferred().resolve( null ).promise();
 	} else {
 		return OSApp.Firmware.sendToOS( "/jsn?pw=", "json" ).then( function( sensors ) {
 			if ( !isCurrentContext() ) {
@@ -1465,6 +1571,15 @@ OSApp.Sites.updateControllerSensorDescription = function( callback, expectedCont
 	}
 
 	if ( session.fw183 === true ) {
+		if ( !isCurrentContext() ) {
+			return rejectStaleSiteControllerRefresh();
+		}
+		controller.sensor_desc = null;
+		callback();
+		return $.Deferred().resolve( controller.sensor_desc ).promise();
+	} else if ( !OSApp.Supported.officialSensorAPIAllowed( controller ) ) {
+
+		// ASB firmware has no /jsd sensor-description schema; see updateControllerSensors.
 		if ( !isCurrentContext() ) {
 			return rejectStaleSiteControllerRefresh();
 		}
@@ -1622,7 +1737,7 @@ OSApp.Sites.refreshData = function() {
 			OSApp.Sites.updateControllerPrograms(),
 			OSApp.Sites.updateControllerStations(),
 		];
-		if ( OSApp.Firmware.checkOSVersion( 2215 ) ) {
+		if ( OSApp.Supported.legacySensorEndpoints() ) {
 			refreshPromises.push( OSApp.Sites.updateControllerSensors() );
 		}
 		$.when.apply( $, refreshPromises ).fail( OSApp.Sites.handleControllerRefreshFailure );

--- a/www/js/modules/sites.js
+++ b/www/js/modules/sites.js
@@ -1134,12 +1134,12 @@ OSApp.Sites.updateController = function( callback, fail ) {
 			fail( error );
 		}
 	};
-	var allowOptionalSensorFailure = function( request, clearUnavailableData ) {
+	var allowMissingSensorEndpoint = function( request, clearUnavailableData ) {
 		var optionalRequest = $.Deferred();
 		request.then( function( data ) {
 			optionalRequest.resolve( data );
 		}, function( error ) {
-			if ( OSApp.Sites.isStaleControllerRefresh( error ) ) {
+			if ( !error || error.status !== 404 ) {
 				optionalRequest.reject( error );
 				return;
 			}
@@ -1180,7 +1180,7 @@ OSApp.Sites.updateController = function( callback, fail ) {
 			// the larger sensor-description schema on /jsd. Prime that schema on
 			// first load so unit labels and sensor controls are immediately ready.
 			if ( Array.isArray( controller.sensors?.sn ) && typeof controller.sensor_desc === "undefined" ) {
-				allowOptionalSensorFailure(
+				allowMissingSensorEndpoint(
 					OSApp.Sites.updateControllerSensorDescription( undefined, context ),
 					function() { controller.sensor_desc = null; }
 				).then( finish, failCurrent );
@@ -1201,11 +1201,11 @@ OSApp.Sites.updateController = function( callback, fail ) {
 			}
 			if ( OSApp.Supported.legacySensorEndpoints( controller ) ) {
 				$.when(
-					allowOptionalSensorFailure(
+					allowMissingSensorEndpoint(
 						OSApp.Sites.updateControllerSensors( undefined, context ),
 						function() { delete controller.sensors; }
 					),
-					allowOptionalSensorFailure(
+					allowMissingSensorEndpoint(
 						OSApp.Sites.updateControllerSensorDescription( undefined, context ),
 						function() { controller.sensor_desc = null; }
 					),

--- a/www/js/modules/status.js
+++ b/www/js/modules/status.js
@@ -258,20 +258,9 @@ OSApp.Status.checkStatus = function() {
 		OSApp.UIDom.changePage( "#os-options", { expandItem: "sensors" } );
 	};
 
-	// Map a sensor type code to a short display name for the footer alert.
-	var sensorTypeShort = function( t ) {
-		switch ( t ) {
-			case 1: return OSApp.Language._( "Rain" );
-			case 2: return OSApp.Language._( "Flow" );
-			case 3: return OSApp.Language._( "Soil" );
-			case 240: return OSApp.Language._( "Program Switch" );
-			default: return OSApp.Language._( "Rain" );
-		}
-	};
-
 	// Build a sensor-active footer message: "{Type} (SN{N}) Activated".
 	var sensorActivatedMsg = function( num, typeCode ) {
-		return "<p class='running-text center pointer'>" + sensorTypeShort( typeCode ) + " (SN" + num + ") " + OSApp.Language._( "Activated" ) + "</p>";
+		return "<p class='running-text center pointer'>" + OSApp.Sensors.getBuiltInSensorTypeName( typeCode, true ) + " (SN" + num + ") " + OSApp.Language._( "Activated" ) + "</p>";
 	};
 
 	// Handle rain sensor triggered (legacy urs/rs scheme — sensor 1 only).

--- a/www/js/modules/supported.js
+++ b/www/js/modules/supported.js
@@ -77,8 +77,16 @@ OSApp.Supported.dateRange = function() {
 	return OSApp.Firmware.checkOSVersion( 220 );
 };
 
+OSApp.Supported.officialSensorAPIAllowed = function( controller ) {
+	return !OSApp.Analog.checkAnalogSensorAvail( controller );
+};
+
+OSApp.Supported.legacySensorEndpoints = function( controller ) {
+	return OSApp.Supported.officialSensorAPIAllowed( controller ) && OSApp.Firmware.checkOSVersion( 2215 );
+};
+
 OSApp.Supported.sensors = function() {
-	return Array.isArray( OSApp.currentSession.controller?.sensors?.sn );
+	return OSApp.Supported.officialSensorAPIAllowed() && Array.isArray( OSApp.currentSession.controller?.sensors?.sn );
 };
 
 OSApp.Supported.changePause = function() {

--- a/www/locale/messages_en.po
+++ b/www/locale/messages_en.po
@@ -2637,3 +2637,26 @@ msgstr ""
 
 msgid "System Diagnostics"
 msgstr ""
+
+msgid "Sensor 3 Update"
+msgstr ""
+
+msgid "Sensor 4 Update"
+msgstr ""
+
+msgid "This UI has limited support for ASB firmware."
+msgstr ""
+
+msgid "ASB firmware detected"
+msgstr ""
+
+msgid "This UI has limited support for it. Switch to OpenSprinklerASB app/UI."
+msgstr ""
+
+msgid "OpenSprinklerASB Firmware Detected"
+msgstr ""
+
+msgid ""
+"Your device runs the OpenSprinklerASB firmware. This UI has limited support "
+"for it. Please switch to the OpenSprinklerASB mobile app/UI for full support."
+msgstr ""


### PR DESCRIPTION
 ## Summary

  - Detect OpenSprinklerASB firmware and avoid unsupported sensor API requests
  - Show a one-time ASB compatibility notice and persistent status notification
  - Add an ASB compatibility note to the About page
  - Support SN3/SN4 notification events
  - Render SN3/SN4 activation records in Sprinkler Logs
  - Centralize built-in sensor naming and event handling
  - Gracefully handle optional sensor-description API failures

  ## Testing

  - Verified ASB controllers no longer fail during controller loading
  - Added regression coverage for ASB detection and SN3/SN4 events
  - Passed JavaScript lint and automated tests
