### PR TITLE
Support custom weather server default providers

### DIFF
--- a/test/tests/weather_provider_checks.js
+++ b/test/tests/weather_provider_checks.js
@@ -1,0 +1,211 @@
+/* eslint-disable */
+
+/* OpenSprinkler App
+ * Copyright (C) 2015 - present, Samer Albahra. All rights reserved.
+ *
+ * This file is part of the OpenSprinkler project <http://opensprinkler.com>.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3 as
+ * published by the Free Software Foundation.
+ */
+
+describe("Weather Server Default Provider Checks", function () {
+	var originalFirmwareMinor, originalFirmwareVersion, originalLocation, originalUseWeather, originalWsp, originalWto;
+
+	beforeEach(function () {
+		originalFirmwareMinor = OSApp.currentSession.controller.options.fwm;
+		originalFirmwareVersion = OSApp.currentSession.controller.options.fwv;
+		originalLocation = OSApp.currentSession.controller.settings.loc;
+		originalUseWeather = OSApp.currentSession.controller.options.uwt;
+		originalWsp = OSApp.currentSession.controller.settings.wsp;
+		originalWto = OSApp.currentSession.controller.settings.wto;
+		OSApp.currentSession.controller.options.fwm = 5;
+		OSApp.currentSession.controller.options.fwv = 221;
+		OSApp.currentSession.controller.settings.loc = "42.36,-71.06";
+		OSApp.currentSession.controller.options.uwt = 1;
+	});
+
+	afterEach(function () {
+		OSApp.currentSession.controller.options.fwm = originalFirmwareMinor;
+		OSApp.currentSession.controller.options.fwv = originalFirmwareVersion;
+		OSApp.currentSession.controller.settings.loc = originalLocation;
+		OSApp.currentSession.controller.options.uwt = originalUseWeather;
+		OSApp.currentSession.controller.settings.wsp = originalWsp;
+		OSApp.currentSession.controller.settings.wto = originalWto;
+		$("#os-options").remove();
+	});
+
+	it("recognizes normalized official weather-server URLs", function () {
+		[
+			"weather.opensprinkler.com",
+			"http://weather.opensprinkler.com",
+			"https://weather.opensprinkler.com",
+			"HTTPS://WEATHER.OPENSPRINKLER.COM/",
+			"https://weather.opensprinkler.com:443/",
+			"http://weather.opensprinkler.com:80/"
+		].forEach(function (url) {
+			assert.isFalse(OSApp.Weather.isCustomWeatherServer(url), url);
+		});
+	});
+
+	it("recognizes custom and empty weather-server values", function () {
+		assert.isTrue(OSApp.Weather.isCustomWeatherServer("http://192.168.1.20:3000"));
+		assert.isTrue(OSApp.Weather.isCustomWeatherServer("http://my-nas.local:8085"));
+		assert.isTrue(OSApp.Weather.isCustomWeatherServer("https://weather.example.net"));
+		assert.isFalse(OSApp.Weather.isCustomWeatherServer(""));
+	});
+
+	it("does not offer Default Provider for the official server", function () {
+		OSApp.currentSession.controller.settings.wsp = "https://weather.opensprinkler.com/";
+		OSApp.currentSession.controller.settings.wto = {};
+		OSApp.Options.showOptions();
+
+		assert.lengthOf($("#weatherSelect option[value='__server_default__']"), 0);
+		assert.equal($("#weatherSelect").val(), "Apple");
+	});
+
+	it("offers Default Provider last and selects it for a custom server without a provider", function () {
+		OSApp.currentSession.controller.settings.wsp = "http://my-nas.local:8085";
+		OSApp.currentSession.controller.settings.wto = {};
+		OSApp.Options.showOptions();
+
+		var options = $("#weatherSelect option");
+		assert.equal(options.last().val(), OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER);
+		assert.equal(options.last().text(), "Default Provider");
+		assert.equal($("#weatherSelect").val(), OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER);
+	});
+
+	it("maps the legacy local provider to Default Provider", function () {
+		assert.equal(
+			OSApp.Weather.getWeatherProviderSelection({ provider: "local" }, "https://weather.example.net"),
+			OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER
+		);
+	});
+
+	it("keeps an explicit cloud provider selected on a custom server", function () {
+		OSApp.currentSession.controller.settings.wsp = "https://weather.example.net";
+		OSApp.currentSession.controller.settings.wto = { provider: "DWD" };
+		OSApp.Options.showOptions();
+
+		assert.equal($("#weatherSelect").val(), "DWD");
+	});
+
+	it("removes provider overrides while preserving adjustment options", function () {
+		var prepared = OSApp.Weather.prepareWeatherOptions({
+			provider: "Apple",
+			key: "old-key",
+			pws: "station",
+			h: 100,
+			t: 90,
+			r: 80,
+			baseETo: 0.2,
+			mda: 100
+		}, OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER, "reinserted-key");
+
+		assert.notProperty(prepared, "provider");
+		assert.notProperty(prepared, "key");
+		assert.notProperty(prepared, "pws");
+		assert.include(prepared, { h: 100, t: 90, r: 80, baseETo: 0.2, mda: 100 });
+	});
+
+	it("updates regular-provider keys without persisting an untouched selector default", function () {
+		var prepared = OSApp.Weather.prepareWeatherOptions({ h: 100 }, "Apple", "new-key");
+
+		assert.deepEqual(prepared, { key: "new-key", h: 100 });
+	});
+
+	it("keeps API-key controls hidden and clear for keyless providers", function () {
+		OSApp.currentSession.controller.settings.wsp = "https://weather.example.net";
+		OSApp.currentSession.controller.settings.wto = { provider: "AW", key: "old-key", pws: "old-pws" };
+		OSApp.Options.showOptions();
+
+		var selector = $("#weatherSelect"),
+			key = $("#wtkey"),
+			keyField = key.parents(".ui-field-contain");
+		selector.val(OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER).trigger("change");
+
+		assert.isTrue(keyField.hasClass("hidden"));
+		assert.isFalse(key.parent().hasClass("red"));
+		assert.deepEqual(OSApp.Utils.unescapeJSON($("#wto").val()), {});
+
+		selector.val("DWD").trigger("change");
+		assert.isTrue(keyField.hasClass("hidden"));
+		assert.isFalse(key.parent().hasClass("red"));
+		assert.equal(OSApp.Utils.unescapeJSON($("#wto").val()).provider, "DWD");
+	});
+
+	it("shows API-key controls only for providers that require a key", function () {
+		OSApp.currentSession.controller.settings.wsp = "https://weather.example.net";
+		OSApp.currentSession.controller.settings.wto = { provider: "DWD" };
+		OSApp.Options.showOptions();
+
+		var selector = $("#weatherSelect"),
+			key = $("#wtkey"),
+			keyField = key.parents(".ui-field-contain");
+		assert.isTrue(keyField.hasClass("hidden"));
+
+		selector.val("AW").trigger("change");
+		assert.isFalse(keyField.hasClass("hidden"));
+		assert.isTrue(key.parent().hasClass("red"));
+	});
+
+	it("submits Default Provider without provider fields or the UI sentinel", function () {
+		OSApp.currentSession.controller.settings.wsp = "https://weather.example.net";
+		OSApp.currentSession.controller.settings.wto = {
+			provider: "WU",
+			key: "old-key",
+			pws: "old-pws",
+			h: 100
+		};
+		var request = sinon.stub(OSApp.Firmware, "sendToOS").returns($.Deferred().promise());
+
+		try {
+			OSApp.Options.showOptions();
+			$("#weatherSelect").val(OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER).trigger("change");
+			$("#os-options .submit").trigger("click");
+
+			assert.isTrue(request.calledOnce);
+			var url = request.firstCall.args[0],
+				params = new URL("http://controller" + url).searchParams,
+				weather = OSApp.Utils.unescapeJSON(params.get("wto"));
+			assert.isFalse(params.has("weatherSelect"));
+			assert.notInclude(url, OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER);
+			assert.deepEqual(weather, { h: 100 });
+		} finally {
+			request.restore();
+		}
+	});
+
+	it("does not persist the displayed Apple default on an official server", function () {
+		OSApp.currentSession.controller.settings.wsp = "weather.opensprinkler.com";
+		OSApp.currentSession.controller.settings.wto = {};
+		var request = sinon.stub(OSApp.Firmware, "sendToOS").returns($.Deferred().promise());
+
+		try {
+			OSApp.Options.showOptions();
+			$("#os-options .submit").trigger("click");
+
+			assert.isTrue(request.calledOnce);
+			var params = new URL("http://controller" + request.firstCall.args[0]).searchParams,
+				weather = OSApp.Utils.unescapeJSON(params.get("wto"));
+			assert.notProperty(weather, "provider");
+		} finally {
+			request.restore();
+		}
+	});
+
+	it("does not verify API keys for Default Provider", function () {
+		OSApp.currentSession.controller.settings.wsp = "https://weather.example.net";
+		OSApp.currentSession.controller.settings.wto = {};
+		var verify = sinon.stub(OSApp.Weather, "testAPIKey");
+
+		try {
+			OSApp.Options.showOptions();
+			$("#verify-api").trigger("click");
+			assert.isFalse(verify.called);
+		} finally {
+			verify.restore();
+		}
+	});
+});

--- a/test/tests/weather_provider_checks.js
+++ b/test/tests/weather_provider_checks.js
@@ -109,6 +109,17 @@ describe("Weather Server Default Provider Checks", function () {
 		assert.include(prepared, { h: 100, t: 90, r: 80, baseETo: 0.2, mda: 100 });
 	});
 
+	it("keeps Default Provider serialization non-empty without adjustment options", function () {
+		var prepared = OSApp.Weather.prepareWeatherOptions({
+			provider: "OpenMeteo",
+			key: "old-key",
+			pws: "old-pws"
+		}, OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER, "reinserted-key");
+
+		assert.deepEqual(prepared, { key: "" });
+		assert.isNotEmpty(OSApp.Utils.escapeJSON(prepared));
+	});
+
 	it("updates regular-provider keys without persisting an untouched selector default", function () {
 		var prepared = OSApp.Weather.prepareWeatherOptions({ h: 100 }, "Apple", "new-key");
 
@@ -172,6 +183,25 @@ describe("Weather Server Default Provider Checks", function () {
 			assert.isFalse(params.has("weatherSelect"));
 			assert.notInclude(url, OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER);
 			assert.deepEqual(weather, { h: 100 });
+		} finally {
+			request.restore();
+		}
+	});
+
+	it("clears a Manual provider override with a non-empty wto request", function () {
+		OSApp.currentSession.controller.options.uwt = 0;
+		OSApp.currentSession.controller.settings.wsp = "https://weather.example.net";
+		OSApp.currentSession.controller.settings.wto = { provider: "OpenMeteo" };
+		var request = sinon.stub(OSApp.Firmware, "sendToOS").returns($.Deferred().promise());
+
+		try {
+			OSApp.Options.showOptions();
+			$("#weatherSelect").val(OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER).trigger("change");
+			$("#os-options .submit").trigger("click");
+
+			assert.isTrue(request.calledOnce);
+			var params = new URL("http://controller" + request.firstCall.args[0]).searchParams;
+			assert.equal(params.get("wto"), '"key":""');
 		} finally {
 			request.restore();
 		}

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -64,8 +64,9 @@ OSApp.Constants = {
 	},
 	weather: {
 		DEFAULT_WEATHER_SERVER_URL: "https://weather.opensprinkler.com",
+		SERVER_DEFAULT_PROVIDER: "__server_default__",
 		PROVIDERS: [
-			{ name: "Apple (Default)", id: "Apple", needsKey: false },
+			{ name: "Apple WeatherKit", id: "Apple", needsKey: false },
 			{ name: "AccuWeather", id: "AW", needsKey: true },
 			{ name: "PirateWeather", id: "PW", needsKey: true },
 			{ name: "Open Weather Map", id: "OWM", needsKey: true },

--- a/www/js/modules/options.js
+++ b/www/js/modules/options.js
@@ -207,7 +207,13 @@ OSApp.Options.showOptions = function( expandItem ) {
 					case "wtkey":
 						return true;
 					case "wto":
-						data = OSApp.Utils.escapeJSON( $.extend( {}, OSApp.Utils.unescapeJSON( data ), { key: page.find( "#wtkey" ).val() } ) );
+						var providerSelect = page.find( "#weatherSelect" ),
+							keyInput = page.find( "#wtkey" );
+						data = OSApp.Utils.escapeJSON( OSApp.Weather.prepareWeatherOptions(
+							OSApp.Utils.unescapeJSON( data ),
+							providerSelect.length ? providerSelect.val() : undefined,
+							keyInput.length ? keyInput.val() : undefined
+						) );
 
 						if ( OSApp.Utils.escapeJSON( OSApp.currentSession.controller.settings.wto ) === data ) {
 							return true;
@@ -274,10 +280,7 @@ OSApp.Options.showOptions = function( expandItem ) {
 						}
 						break;
 					case "weatherSelect":
-						if ( OSApp.currentSession.controller.settings.wto && OSApp.currentSession.controller.settings.wto.provider && OSApp.Utils.escapeJSON( OSApp.currentSession.controller.settings.wto.provider ) === data ) {
-							return true;
-						}
-						break;
+						return true;
 					case "mda":
 						if ( OSApp.currentSession.controller.settings.wto && OSApp.currentSession.controller.settings.wto.mda && OSApp.Utils.escapeJSON( OSApp.currentSession.controller.settings.wto.mda ) === data ) {
 							return true;
@@ -671,21 +674,31 @@ OSApp.Options.showOptions = function( expandItem ) {
 		}
 	}
 
+		var weatherOptions = OSApp.currentSession.controller.settings.wto || {},
+			customWeatherServer = OSApp.Weather.isCustomWeatherServer(),
+			selectedWeatherProvider = OSApp.Weather.getWeatherProviderSelection( weatherOptions );
+
 		if ( typeof OSApp.currentSession.controller?.settings?.wsp !== "undefined" ) {
 			list += "<div class='ui-field-contain'><label for='weatherSelect' class='select'>" + OSApp.Language._( "Weather Data Provider" ) +
 					"<button data-helptext='" +
-						OSApp.Language._( "Select your preferred weather service provider." ) +
+						( selectedWeatherProvider === OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER ? OSApp.Language._( "Uses the provider configured on the custom weather server." ) : OSApp.Language._( "Select your preferred weather service provider." ) ) +
 						"' class='help-icon btn-no-border ui-btn ui-icon-info ui-btn-icon-notext'></button>" +
 				"</label><select data-mini='true' id='weatherSelect'>";
 			for ( i = 0; i < OSApp.Constants.weather.PROVIDERS.length; i++ ) {
 				var weatherProvider = OSApp.Weather.getWeatherProviderById( i );
-				list += "<option " + ( ( weatherProvider.id === OSApp.currentSession.controller.settings.wto.provider ) ? "selected" : "" ) + " value='" + weatherProvider.id + "'>" + weatherProvider.name + "</option>";
+				list += "<option " + ( ( weatherProvider.id === selectedWeatherProvider ) ? "selected" : "" ) + " value='" + weatherProvider.id + "'>" + weatherProvider.name + "</option>";
+			}
+			if ( customWeatherServer ) {
+				list += "<option " + ( selectedWeatherProvider === OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER ? "selected" : "" ) +
+					" value='" + OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER + "'>" + OSApp.Language._( "Default Provider" ) + "</option>";
 			}
 			list += "</select></div>";
 		}
 
 		if ( OSApp.Supported.verifyWeatherAPIKey() ) {
-			list += "<div class='ui-field-contain" + ( OSApp.Weather.getCurrentWeatherProvider().needsKey ? "" : " hidden" ) + "'><label for='wtkey'>" + OSApp.Language._( "Weather API Key" ) +
+			var selectedProvider = OSApp.Weather.getWeatherProviderById( selectedWeatherProvider ),
+				providerNeedsKey = !!( selectedProvider && selectedProvider.needsKey );
+			list += "<div class='ui-field-contain" + ( providerNeedsKey ? "" : " hidden" ) + "'><label for='wtkey'>" + OSApp.Language._( "Weather API Key" ) +
 				"<button data-helptext='" +
 				OSApp.Language._( "Please enter an API key for your selected weather provider." ) +
 					"' class='help-icon btn-no-border ui-btn ui-icon-info ui-btn-icon-notext'></button>" +
@@ -694,10 +707,10 @@ OSApp.Options.showOptions = function( expandItem ) {
 				"<tr style='width:100%;vertical-align: top;'>" +
 					"<td style='width:100%'>" +
 						"<div class='" +
-							( ( OSApp.currentSession.controller.settings.wto.key && OSApp.currentSession.controller.settings.wto.key !== "" ) ? "" : "red " ) +
+							( providerNeedsKey && !weatherOptions.key ? "red " : "" ) +
 							"ui-input-text controlgroup-textinput ui-btn ui-body-inherit ui-corner-all ui-mini ui-shadow-inset ui-input-has-clear'>" +
 								"<input data-role='none' data-mini='true' autocomplete='off' autocorrect='off' autocapitalize='off' spellcheck='false' " +
-									"type='text' id='wtkey' value='" + ( OSApp.currentSession.controller.settings.wto.key || "" ) + "'>" +
+									"type='text' id='wtkey' value='" + ( weatherOptions.key || "" ) + "'>" +
 								"<a href='#' tabindex='-1' aria-hidden='true' data-helptext='" + OSApp.Language._( "An invalid API key has been detected." ) +
 									"' class='hidden help-icon ui-input-clear ui-btn ui-icon-alert ui-btn-icon-notext ui-corner-all'>" +
 								"</a>" +
@@ -1467,10 +1480,28 @@ OSApp.Options.showOptions = function( expandItem ) {
 		}
 	} );
 
+	var updateWeatherApiKeyControls = function( providerId ) {
+		var key = page.find( "#wtkey" ),
+			provider = OSApp.Weather.getWeatherProviderById( providerId ),
+			needsKey = !!( provider && provider.needsKey );
+
+		key.parents( ".ui-field-contain" ).toggleClass( "hidden", !needsKey );
+		key.parent().removeClass( "red green" );
+		key.siblings( ".help-icon" ).hide();
+		if ( needsKey && !key.val() ) {
+			key.parent().addClass( "red" );
+		}
+		return needsKey;
+	};
+
 	page.find( "#verify-api" ).on( "click", function() {
 		var key = page.find( "#wtkey" ),
 			button = $( this ),
 			provider = page.find( "#weatherSelect" );
+
+		if ( !updateWeatherApiKeyControls( provider.val() ) ) {
+			return false;
+		}
 
 		button.prop( "disabled", true );
 
@@ -1490,13 +1521,22 @@ OSApp.Options.showOptions = function( expandItem ) {
 		//remove status from API key entry to prompt re-verify
 		page.find( "#wtkey" ).siblings( ".help-icon" ).hide();
 		page.find( "#wtkey" ).parent().removeClass( "red green" );
-		//make API key input appear if needed
-		page.find( "#wtkey" ).parents( ".ui-field-contain" ).toggleClass( "hidden", !(OSApp.Weather.getWeatherProviderById( this.value ).needsKey));
 		//change wto value based on new selection
 		let curr = OSApp.Utils.unescapeJSON(page.find( "#wto" ).val());
-		curr.provider = this.value;
+		if ( this.value === OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER ) {
+			delete curr.provider;
+			delete curr.key;
+			delete curr.pws;
+		} else {
+			curr.provider = this.value;
+		}
 		page.find( "#wtkey" ).prop( "value", "" );
-		page.find( "#wtkey" ).parent().addClass( "red" );
+		updateWeatherApiKeyControls( this.value );
+		page.find( "label[for='weatherSelect'] .help-icon" ).attr( "data-helptext",
+			this.value === OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER ?
+				OSApp.Language._( "Uses the provider configured on the custom weather server." ) :
+				OSApp.Language._( "Select your preferred weather service provider." )
+		);
 		page.find( "#wto" ).prop( "value", OSApp.Utils.escapeJSON(curr));
 	} );
 

--- a/www/js/modules/weather.js
+++ b/www/js/modules/weather.js
@@ -989,6 +989,11 @@ OSApp.Weather.prepareWeatherOptions = function( options, provider, key ) {
 		delete prepared.provider;
 		delete prepared.key;
 		delete prepared.pws;
+		// Firmware ignores an empty wto parameter, so retain a harmless empty
+		// key when no adjustment options remain to make provider clearing stick.
+		if ( Object.keys( prepared ).length === 0 ) {
+			prepared.key = "";
+		}
 		return prepared;
 	}
 

--- a/www/js/modules/weather.js
+++ b/www/js/modules/weather.js
@@ -720,7 +720,7 @@ OSApp.Weather.checkURLandUpdateWeather = function() {
 	};
 
 	if ( OSApp.currentSession.controller?.settings?.wsp ) {
-		if ( OSApp.currentSession.controller.settings.wsp === "weather.opensprinkler.com" ) {
+		if ( !OSApp.Weather.isCustomWeatherServer( OSApp.currentSession.controller.settings.wsp ) ) {
 			finish();
 			return;
 		}
@@ -733,6 +733,32 @@ OSApp.Weather.checkURLandUpdateWeather = function() {
 		var wsp = reply.match( /value="([\w|:|/|.]+)" name=wsp/ );
 		finish( wsp ? wsp[ 1 ] : undefined );
 	} );
+};
+
+OSApp.Weather.isCustomWeatherServer = function( weatherServer ) {
+	if ( typeof weatherServer === "undefined" ) {
+		weatherServer = OSApp.currentSession.controller?.settings?.wsp;
+	}
+
+	if ( typeof weatherServer !== "string" || weatherServer.trim() === "" ) {
+		return false;
+	}
+
+	var normalized = weatherServer.trim();
+	if ( !/^https?:\/\//i.test( normalized ) ) {
+		normalized = "https://" + normalized;
+	}
+
+	try {
+		var parsed = new URL( normalized );
+		return parsed.hostname.toLowerCase() !== "weather.opensprinkler.com" ||
+			parsed.port !== "" ||
+			parsed.pathname.replace( /\/+$/, "" ) !== "" ||
+			parsed.search !== "" ||
+			parsed.hash !== "";
+	} catch {
+		return true;
+	}
 };
 
 OSApp.Weather.updateWeatherBox = function() {
@@ -948,12 +974,28 @@ OSApp.Weather.getWeatherProviderById = function( id ) {
 	return false;
 };
 
-OSApp.Weather.getCurrentWeatherProvider = function() {
-	const provider = OSApp.Weather.getWeatherProviderById(OSApp.currentSession.controller.settings.wto.provider);
-	if(provider)
-		return provider;
+OSApp.Weather.getWeatherProviderSelection = function( options, weatherServer ) {
+	options = options || {};
+	if ( OSApp.Weather.isCustomWeatherServer( weatherServer ) && ( !options.provider || options.provider === "local" ) ) {
+		return OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER;
+	}
 
-	return false;
+	return options.provider;
+};
+
+OSApp.Weather.prepareWeatherOptions = function( options, provider, key ) {
+	var prepared = $.extend( {}, options || {} );
+	if ( provider === OSApp.Constants.weather.SERVER_DEFAULT_PROVIDER ) {
+		delete prepared.provider;
+		delete prepared.key;
+		delete prepared.pws;
+		return prepared;
+	}
+
+	if ( typeof key !== "undefined" ) {
+		prepared.key = key;
+	}
+	return prepared;
 };
 
 OSApp.Weather.testAPIKey = function( key, provider, callback ) {

--- a/www/locale/messages_en.po
+++ b/www/locale/messages_en.po
@@ -1171,6 +1171,12 @@ msgstr ""
 msgid "Select your preferred weather service provider."
 msgstr ""
 
+msgid "Uses the provider configured on the custom weather server."
+msgstr ""
+
+msgid "Default Provider"
+msgstr ""
+
 msgid "Weather API Key"
 msgstr ""
 


### PR DESCRIPTION
## Summary
- add a Default Provider choice for controllers using a custom weather server
- preserve Apple WeatherKit as the official-server default
- remove provider, key, and PWS overrides when the weather server should choose its configured provider
- normalize official weather-server URL variants and keep API-key controls consistent for keyless providers

## Testing
- npm run lint
- npm test (285 passing)